### PR TITLE
feat(mcp): declarative grid metadata and smart grid recommender

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,11 @@ jobs:
 
       - name: Lint with Ruff
         run: |
-          # Pin to the lockfile version — unpinned uvx pulls latest and can
-          # fail the tree on rule-set churn (e.g. ruff 0.16).
-          uvx ruff@0.15.8 check phil/
+          uvx ruff check phil/
 
       - name: Check code formatting with Ruff
         run: |
-          uvx ruff@0.15.8 format --check phil/
+          uvx ruff format --check phil/
 
   test:
     runs-on: ubuntu-latest
@@ -69,4 +67,5 @@ jobs:
       - name: Test summary
         run: |
           echo "✅ All tests passed for Python ${{ matrix.python-version }}"
+
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,13 @@ jobs:
 
       - name: Lint with Ruff
         run: |
-          uvx ruff check phil/
+          # Pin to the lockfile version — unpinned uvx pulls latest and can
+          # fail the tree on rule-set churn (e.g. ruff 0.16).
+          uvx ruff@0.15.8 check phil/
 
       - name: Check code formatting with Ruff
         run: |
-          uvx ruff format --check phil/
+          uvx ruff@0.15.8 format --check phil/
 
   test:
     runs-on: ubuntu-latest
@@ -67,3 +69,4 @@ jobs:
       - name: Test summary
         run: |
           echo "✅ All tests passed for Python ${{ matrix.python-version }}"
+

--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ Example Claude Desktop config (`~/Library/Application Support/Claude/claude_desk
 ```
 
 The server exposes tools for the full sweep workflow — `ingest_dataset`,
-`characterize_dataset`, `list_grids`, `create_config`, `validate_config`,
-`run_imputation_sweep`, `diagnose_sweep`, `export_imputed_data`, and more.
+`characterize_dataset`, `recommend_grid`, `list_grids`, `create_config`,
+`validate_config`, `run_imputation_sweep`, `diagnose_sweep`,
+`export_imputed_data`, and more. Agents can also read the
+`phil://docs/imputation-matrix` resource for grid comparison metadata.
 Polars users write to Parquet and ingest the file path. See the
 [MCP guide](docs/source/userGuides/mcp.rst) for setup tabs, the full tool
 table, and an example dialog.

--- a/docs/source/userGuides/mcp.rst
+++ b/docs/source/userGuides/mcp.rst
@@ -205,8 +205,10 @@ chains them together:
      - Sparse per-column schema: dtype, n_unique, missing percent, plus aggregate row/column counts. Cheap and safe to call on wide datasets.
    * - **probe_columns**
      - Deep per-column inspection for up to 20 columns at a time: sample values, top frequencies, basic numeric statistics.
+   * - **recommend_grid**
+     - Rule-based grid recommendation from dataset scale, categorical cardinality, and missingness. Returns a concrete grid, suggested ``samples``, warnings, and rationale.
    * - **list_grids**
-     - Enumerates the named ``GridGallery`` entries (``default``, ``sampling``, ``finance``, ``healthcare``, ``marketing``, ``engineering``) with method lists and intent blurbs.
+     - Enumerates the named ``GridGallery`` entries (``default``, ``sampling``, ``finance``, ``healthcare``, ``marketing``, ``engineering``) with declarative metadata (intent, suitability, affinity, time complexity, scale limits).
    * - **create_config**
      - Materializes a canonical YAML config tailored to a ``dataset_id`` and grid choice. Stores it on the session so subsequent ``refine_active_config`` / ``run_imputation_sweep`` calls can omit it.
    * - **validate_config**
@@ -230,6 +232,13 @@ chains them together:
    * - **export_imputed_data**
      - Writes the selected imputed DataFrame to disk; CSV / Parquet / Feather inferred from the extension.
 
+Resources
+^^^^^^^^^
+
+* ``phil://docs/imputation-matrix`` — Markdown comparison matrix of built-in
+  grids (domain, complexity, affinity, scale limits, estimator cost notes),
+  compiled from declarative ``GRID_METADATA``.
+
 Example: A Mixed-Type Frame with Missing Values
 -----------------------------------------------
 
@@ -250,7 +259,7 @@ A successful agent dialog looks like:
 1. ``ingest_dataset("/data/demo.csv")`` → ``dataset_id="ds_abc123"``
 2. ``characterize_dataset("ds_abc123")`` → reports 4 missing in ``income``,
    1 missing in ``category``, etc.
-3. ``list_grids()`` → agent picks ``default``
+3. ``recommend_grid("ds_abc123")`` → recommends ``default`` with suggested samples
 4. ``create_config("ds_abc123", grid="default", samples=20)``
 5. ``run_imputation_sweep`` → returns ``selected_index=7``,
    ``descriptor_stats.mean_pairwise_l2=0.14``

--- a/phil/__init__.py
+++ b/phil/__init__.py
@@ -18,14 +18,14 @@ from phil.visualization import plot_mds
 
 __version__ = "0.1.0"
 __all__ = [
-    "Phil",
-    "PhilTransformer",
-    "GridGallery",
     "ECT",
-    "ECTConfig",
-    "ImputationConfig",
-    "PreprocessingConfig",
     "CovariateDistributionImputer",
     "DistributionImputer",
+    "ECTConfig",
+    "GridGallery",
+    "ImputationConfig",
+    "Phil",
+    "PhilTransformer",
+    "PreprocessingConfig",
     "plot_mds",
 ]

--- a/phil/gallery.py
+++ b/phil/gallery.py
@@ -314,8 +314,7 @@ class GridGallery:
             grids=[
                 ParameterGrid(
                     {
-                        "strategy": ["most_frequent", "constant"],
-                        "fill_value": ["unknown"],
+                        "strategy": ["most_frequent", "mean", "median"],
                     }
                 ),
                 ParameterGrid({"n_neighbors": [3, 5], "weights": ["uniform"]}),

--- a/phil/gallery.py
+++ b/phil/gallery.py
@@ -69,9 +69,7 @@ GRID_METADATA: dict[str, GridMetadata] = {
     "finance": GridMetadata(
         name="finance",
         target_domain="finance",
-        intent=(
-            "Iterative + KNN + Simple imputers tuned for tabular financial data."
-        ),
+        intent=("Iterative + KNN + Simple imputers tuned for tabular financial data."),
         suitability=(
             "Use for asset/returns-style tables with outliers and correlated "
             "continuous metrics (pairs well with RobustScaler preprocessing)."
@@ -184,9 +182,7 @@ def render_imputation_matrix() -> str:
     lines.append("")
     lines.append("## Estimator / complexity notes")
     lines.append("")
-    lines.append(
-        "| Grid | Methods (summary) | Big-O / cost notes |"
-    )
+    lines.append("| Grid | Methods (summary) | Big-O / cost notes |")
     lines.append("| --- | --- | --- |")
     lines.append(
         "| `default` | BayesianRidge, trees, forests, GBM | "
@@ -196,22 +192,12 @@ def render_imputation_matrix() -> str:
         "| `sampling` | DistributionImputer (many seeds) | "
         "Linear in N · seeds; Medium |"
     )
+    lines.append("| `finance` | Iterative + KNN + Simple | KNN ~O(N²); High |")
+    lines.append("| `healthcare` | KNN + Simple + Iterative | KNN ~O(N²); High |")
     lines.append(
-        "| `finance` | Iterative + KNN + Simple | "
-        "KNN ~O(N²); High |"
+        "| `marketing` | Simple + KNN + Iterative | Lighter KNN grids; Medium |"
     )
-    lines.append(
-        "| `healthcare` | KNN + Simple + Iterative | "
-        "KNN ~O(N²); High |"
-    )
-    lines.append(
-        "| `marketing` | Simple + KNN + Iterative | "
-        "Lighter KNN grids; Medium |"
-    )
-    lines.append(
-        "| `engineering` | Simple + KNN + Iterative | "
-        "Modest KNN; Medium |"
-    )
+    lines.append("| `engineering` | Simple + KNN + Iterative | Modest KNN; Medium |")
     lines.append("")
     return "\n".join(lines)
 
@@ -409,4 +395,3 @@ class MagicGallery:
                 seed=42,
             )
         raise ValueError(f"Unknown magic method: {method}")
-

--- a/phil/gallery.py
+++ b/phil/gallery.py
@@ -1,6 +1,9 @@
 """Collection of predefined configurations for Phil."""
 
-from typing import Dict
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List
 
 import numpy as np
 from pydantic import BaseModel
@@ -8,6 +11,209 @@ from sklearn.model_selection import ParameterGrid
 
 from phil.imputation import ImputationConfig, PreprocessingConfig
 from phil.magic import ECTConfig
+
+
+@dataclass(frozen=True)
+class GridMetadata:
+    """Declarative, agent-readable metadata for a built-in imputation grid."""
+
+    name: str
+    target_domain: str
+    intent: str
+    suitability: str
+    data_type_affinity: List[str]
+    time_complexity: str  # "Low" | "Medium" | "High"
+    scale_limits: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+GRID_METADATA: dict[str, GridMetadata] = {
+    "default": GridMetadata(
+        name="default",
+        target_domain="general",
+        intent=(
+            "Mixed regression imputers across BayesianRidge, Decision Tree, "
+            "Random Forest, and Gradient Boosting."
+        ),
+        suitability=(
+            "Good starting point for mixed continuous tabular data when no "
+            "domain-specific prior applies."
+        ),
+        data_type_affinity=["continuous", "mixed"],
+        time_complexity="Medium",
+        scale_limits=(
+            "Comfortable under ~100k rows. Tree ensembles dominate cost; "
+            "lower samples if sweeps are slow."
+        ),
+    ),
+    "sampling": GridMetadata(
+        name="sampling",
+        target_domain="distributional",
+        intent=(
+            "Distribution sampling imputation across 100 seeds "
+            "(good for preserving marginals)."
+        ),
+        suitability=(
+            "Prefer when the goal is to preserve marginal distributions "
+            "rather than conditional structure (multiverse-style sampling)."
+        ),
+        data_type_affinity=["continuous"],
+        time_complexity="Medium",
+        scale_limits=(
+            "Scales with sample count and seeds. Safer than KNN on large N; "
+            "still reduce samples on very wide tables."
+        ),
+    ),
+    "finance": GridMetadata(
+        name="finance",
+        target_domain="finance",
+        intent=(
+            "Iterative + KNN + Simple imputers tuned for tabular financial data."
+        ),
+        suitability=(
+            "Use for asset/returns-style tables with outliers and correlated "
+            "continuous metrics (pairs well with RobustScaler preprocessing)."
+        ),
+        data_type_affinity=["continuous", "correlated"],
+        time_complexity="High",
+        scale_limits=(
+            "KNN and iterative estimators dominate; keep rows <100k or reduce "
+            "samples. Avoid blind sweeps on half-million-row tables."
+        ),
+    ),
+    "healthcare": GridMetadata(
+        name="healthcare",
+        target_domain="healthcare",
+        intent="KNN, Simple, and Iterative imputers tuned for clinical tables.",
+        suitability=(
+            "Required for medical metrics with non-Gaussian distributions "
+            "(ordinal scaling + robust bounds)."
+        ),
+        data_type_affinity=["continuous", "ordinal", "mixed"],
+        time_complexity="High",
+        scale_limits=(
+            "Overhead scales quadratically O(N^2) due to KNN. Keep row count "
+            "<100,000 or reduce sample size."
+        ),
+    ),
+    "marketing": GridMetadata(
+        name="marketing",
+        target_domain="marketing",
+        intent="Categorical-friendly Simple, KNN, and Iterative imputers.",
+        suitability=(
+            "Choose for consumer analytics with high-cardinality categoricals "
+            "(zip codes, product IDs); pairs with TargetEncoder preprocessing."
+        ),
+        data_type_affinity=["categorical", "high-cardinality", "mixed"],
+        time_complexity="Medium",
+        scale_limits=(
+            "KNN still present but lighter neighbor grids. Watch cardinality "
+            "explosion; reduce samples on wide categorical tables."
+        ),
+    ),
+    "engineering": GridMetadata(
+        name="engineering",
+        target_domain="engineering",
+        intent=(
+            "Robust mean/median + KNN + Decision-Tree iterative imputation "
+            "for sensor data."
+        ),
+        suitability=(
+            "Prefer for sensor / industrial measurements where mean/median "
+            "baselines plus modest KNN coverage are enough."
+        ),
+        data_type_affinity=["continuous", "sensor"],
+        time_complexity="Medium",
+        scale_limits=(
+            "Moderate KNN cost. Suitable under ~100k rows; lower samples if "
+            "neighbor search dominates runtime."
+        ),
+    ),
+}
+
+
+def get_grid_metadata(name: str) -> GridMetadata | None:
+    """Return metadata for a built-in grid, or ``None`` if unknown."""
+    return GRID_METADATA.get(name)
+
+
+def list_grid_metadata() -> list[GridMetadata]:
+    """Return metadata for all agent-facing built-in grids (sorted by name)."""
+    return [GRID_METADATA[name] for name in sorted(GRID_METADATA)]
+
+
+def render_imputation_matrix() -> str:
+    """Compile a Markdown comparison matrix from ``GRID_METADATA``."""
+    headers = (
+        "Grid",
+        "Domain",
+        "Complexity",
+        "Affinity",
+        "Scale limits",
+        "Suitability",
+    )
+    lines = [
+        "# Phil Imputation Grid Matrix",
+        "",
+        "Compiled from declarative ``GRID_METADATA`` (single source of truth).",
+        "",
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for meta in list_grid_metadata():
+        affinity = ", ".join(meta.data_type_affinity)
+        # Escape pipes so Markdown tables stay intact.
+        suitability = meta.suitability.replace("|", "\\|")
+        scale = meta.scale_limits.replace("|", "\\|")
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    f"`{meta.name}`",
+                    meta.target_domain,
+                    meta.time_complexity,
+                    affinity,
+                    scale,
+                    suitability,
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    lines.append("## Estimator / complexity notes")
+    lines.append("")
+    lines.append(
+        "| Grid | Methods (summary) | Big-O / cost notes |"
+    )
+    lines.append("| --- | --- | --- |")
+    lines.append(
+        "| `default` | BayesianRidge, trees, forests, GBM | "
+        "Ensemble fits ~O(N log N · trees); Medium |"
+    )
+    lines.append(
+        "| `sampling` | DistributionImputer (many seeds) | "
+        "Linear in N · seeds; Medium |"
+    )
+    lines.append(
+        "| `finance` | Iterative + KNN + Simple | "
+        "KNN ~O(N²); High |"
+    )
+    lines.append(
+        "| `healthcare` | KNN + Simple + Iterative | "
+        "KNN ~O(N²); High |"
+    )
+    lines.append(
+        "| `marketing` | Simple + KNN + Iterative | "
+        "Lighter KNN grids; Medium |"
+    )
+    lines.append(
+        "| `engineering` | Simple + KNN + Iterative | "
+        "Modest KNN; Medium |"
+    )
+    lines.append("")
+    return "\n".join(lines)
 
 
 class GridGallery:
@@ -204,3 +410,4 @@ class MagicGallery:
                 seed=42,
             )
         raise ValueError(f"Unknown magic method: {method}")
+

--- a/phil/gallery.py
+++ b/phil/gallery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
 from pydantic import BaseModel
@@ -255,7 +255,7 @@ class GridGallery:
     - Engineering: Thomas & Rajabi (2021) and Idri et al. (2016) on systematic reviews of engineering data.
     """
 
-    _grids = {
+    _grids: ClassVar[dict[str, ImputationConfig]] = {
         "default": ImputationConfig(
             methods=[
                 "BayesianRidge",
@@ -392,7 +392,7 @@ class ProcessingGallery:
       as discussed in Anand & Mamidi (2020).
     """
 
-    _numeric_methods = {
+    _numeric_methods: ClassVar[dict[str, PreprocessingConfig]] = {
         "default": PreprocessingConfig(method="StandardScaler"),
         "finance": PreprocessingConfig(method="RobustScaler"),
         "healthcare": PreprocessingConfig(method="RobustScaler"),
@@ -402,7 +402,7 @@ class ProcessingGallery:
         "engineering": PreprocessingConfig(method="StandardScaler"),
     }
 
-    _categorical_methods = {
+    _categorical_methods: ClassVar[dict[str, PreprocessingConfig]] = {
         "default": PreprocessingConfig(method="OneHotEncoder"),
         "finance": PreprocessingConfig(
             method="OneHotEncoder", params={"handle_unknown": ["ignore"]}

--- a/phil/gallery.py
+++ b/phil/gallery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List
+from typing import Any
 
 import numpy as np
 from pydantic import BaseModel
@@ -21,7 +21,7 @@ class GridMetadata:
     target_domain: str
     intent: str
     suitability: str
-    data_type_affinity: List[str]
+    data_type_affinity: tuple[str, ...]
     time_complexity: str  # "Low" | "Medium" | "High"
     scale_limits: str
 
@@ -41,7 +41,7 @@ GRID_METADATA: dict[str, GridMetadata] = {
             "Good starting point for mixed continuous tabular data when no "
             "domain-specific prior applies."
         ),
-        data_type_affinity=["continuous", "mixed"],
+        data_type_affinity=("continuous", "mixed"),
         time_complexity="Medium",
         scale_limits=(
             "Comfortable under ~100k rows. Tree ensembles dominate cost; "
@@ -59,7 +59,7 @@ GRID_METADATA: dict[str, GridMetadata] = {
             "Prefer when the goal is to preserve marginal distributions "
             "rather than conditional structure (multiverse-style sampling)."
         ),
-        data_type_affinity=["continuous"],
+        data_type_affinity=("continuous",),
         time_complexity="Medium",
         scale_limits=(
             "Scales with sample count and seeds. Safer than KNN on large N; "
@@ -74,7 +74,7 @@ GRID_METADATA: dict[str, GridMetadata] = {
             "Use for asset/returns-style tables with outliers and correlated "
             "continuous metrics (pairs well with RobustScaler preprocessing)."
         ),
-        data_type_affinity=["continuous", "correlated"],
+        data_type_affinity=("continuous", "correlated"),
         time_complexity="High",
         scale_limits=(
             "KNN and iterative estimators dominate; keep rows <100k or reduce "
@@ -89,7 +89,7 @@ GRID_METADATA: dict[str, GridMetadata] = {
             "Required for medical metrics with non-Gaussian distributions "
             "(ordinal scaling + robust bounds)."
         ),
-        data_type_affinity=["continuous", "ordinal", "mixed"],
+        data_type_affinity=("continuous", "ordinal", "mixed"),
         time_complexity="High",
         scale_limits=(
             "Overhead scales quadratically O(N^2) due to KNN. Keep row count "
@@ -99,12 +99,15 @@ GRID_METADATA: dict[str, GridMetadata] = {
     "marketing": GridMetadata(
         name="marketing",
         target_domain="marketing",
-        intent="Categorical-friendly Simple, KNN, and Iterative imputers.",
+        intent=(
+            "SimpleImputer (most_frequent/mean/median), KNN, and Iterative "
+            "imputers for mixed consumer tables (post-encoding numeric matrix)."
+        ),
         suitability=(
             "Choose for consumer analytics with high-cardinality categoricals "
-            "(zip codes, product IDs); pairs with TargetEncoder preprocessing."
+            "(zip codes, product IDs)."
         ),
-        data_type_affinity=["categorical", "high-cardinality", "mixed"],
+        data_type_affinity=("categorical", "high-cardinality", "mixed"),
         time_complexity="Medium",
         scale_limits=(
             "KNN still present but lighter neighbor grids. Watch cardinality "
@@ -122,7 +125,7 @@ GRID_METADATA: dict[str, GridMetadata] = {
             "Prefer for sensor / industrial measurements where mean/median "
             "baselines plus modest KNN coverage are enough."
         ),
-        data_type_affinity=["continuous", "sensor"],
+        data_type_affinity=("continuous", "sensor"),
         time_complexity="Medium",
         scale_limits=(
             "Moderate KNN cost. Suitable under ~100k rows; lower samples if "
@@ -142,8 +145,55 @@ def list_grid_metadata() -> list[GridMetadata]:
     return [GRID_METADATA[name] for name in sorted(GRID_METADATA)]
 
 
+def grid_candidate_count(grid_name: str) -> int:
+    """Number of ParameterGrid candidates for a built-in gallery grid."""
+    grid = GridGallery.get(grid_name)
+    return sum(len(list(param_grid)) for param_grid in grid.grids)
+
+
+def grid_scalability(grid_name: str) -> dict[str, Any]:
+    """Expose candidate count / KNN risk so agents can budget compute."""
+    grid = GridGallery.get(grid_name)
+    methods = list(grid.methods)
+    n_candidates = sum(len(list(param_grid)) for param_grid in grid.grids)
+    has_knn = any("KNN" in method for method in methods)
+    has_iterative = any("Iterative" in method for method in methods)
+    has_tree_ensemble = any(
+        method
+        in {
+            "RandomForestRegressor",
+            "GradientBoostingRegressor",
+            "ExtraTreesRegressor",
+        }
+        for method in methods
+    )
+    if has_knn:
+        big_o = "O(N^2) neighbor search dominates when KNN is in the grid"
+        cost_tier = "high" if n_candidates >= 7 else "medium_high"
+    elif has_tree_ensemble:
+        big_o = "O(N log N · trees) per iterative/ensemble fit"
+        cost_tier = "medium"
+    elif has_iterative:
+        big_o = "O(N · P · iters) chained / iterative updates"
+        cost_tier = "medium"
+    else:
+        big_o = "Near-linear in N for simple / distributional imputers"
+        # sampling metadata says Medium; live cost is low without KNN/trees.
+        cost_tier = "low"
+
+    return {
+        "grid_candidate_count": n_candidates,
+        "methods": methods,
+        "has_knn": has_knn,
+        "has_iterative": has_iterative,
+        "has_tree_ensemble": has_tree_ensemble,
+        "cost_tier": cost_tier,
+        "complexity_note": big_o,
+    }
+
+
 def render_imputation_matrix() -> str:
-    """Compile a Markdown comparison matrix from ``GRID_METADATA``."""
+    """Compile a Markdown comparison matrix from `GRID_METADATA` + live grids."""
     headers = (
         "Grid",
         "Domain",
@@ -155,7 +205,7 @@ def render_imputation_matrix() -> str:
     lines = [
         "# Phil Imputation Grid Matrix",
         "",
-        "Compiled from declarative ``GRID_METADATA`` (single source of truth).",
+        "Compiled from declarative `GRID_METADATA` and live `GridGallery` configs.",
         "",
         "| " + " | ".join(headers) + " |",
         "| " + " | ".join("---" for _ in headers) + " |",
@@ -182,22 +232,13 @@ def render_imputation_matrix() -> str:
     lines.append("")
     lines.append("## Estimator / complexity notes")
     lines.append("")
-    lines.append("| Grid | Methods (summary) | Big-O / cost notes |")
-    lines.append("| --- | --- | --- |")
-    lines.append(
-        "| `default` | BayesianRidge, trees, forests, GBM | "
-        "Ensemble fits ~O(N log N · trees); Medium |"
-    )
-    lines.append(
-        "| `sampling` | DistributionImputer (many seeds) | "
-        "Linear in N · seeds; Medium |"
-    )
-    lines.append("| `finance` | Iterative + KNN + Simple | KNN ~O(N²); High |")
-    lines.append("| `healthcare` | KNN + Simple + Iterative | KNN ~O(N²); High |")
-    lines.append(
-        "| `marketing` | Simple + KNN + Iterative | Lighter KNN grids; Medium |"
-    )
-    lines.append("| `engineering` | Simple + KNN + Iterative | Modest KNN; Medium |")
+    lines.append("| Grid | Methods | Cost tier | Big-O / cost notes |")
+    lines.append("| --- | --- | --- | --- |")
+    for meta in list_grid_metadata():
+        scale = grid_scalability(meta.name)
+        methods = ", ".join(scale["methods"])
+        note = scale["complexity_note"].replace("|", "\\|")
+        lines.append(f"| `{meta.name}` | {methods} | {scale['cost_tier']} | {note} |")
     lines.append("")
     return "\n".join(lines)
 
@@ -374,7 +415,7 @@ class ProcessingGallery:
     }
 
     @classmethod
-    def get(cls, name: str = "default") -> Dict[str, PreprocessingConfig]:
+    def get(cls, name: str = "default") -> dict[str, PreprocessingConfig]:
         return {
             "num": cls._numeric_methods.get(name, cls._numeric_methods["default"]),
             "cat": cls._categorical_methods.get(

--- a/phil/imputation/__init__.py
+++ b/phil/imputation/__init__.py
@@ -11,6 +11,6 @@ __all__ = [
     "CovariateDistributionImputer",
     "DistributionImputer",
     "ImputationConfig",
-    "PreprocessingConfig",
     "MaskedIterativeImputer",
+    "PreprocessingConfig",
 ]

--- a/phil/imputation/config.py
+++ b/phil/imputation/config.py
@@ -2,26 +2,26 @@
 Configuration models for Phil's imputation strategies.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 from sklearn.model_selection import ParameterGrid
 
 
 class CovariateSubset(BaseModel):
-    predictors: List[str]
-    citations: List[str]
+    predictors: list[str]
+    citations: list[str]
 
 
 class CovarianceMatrix(BaseModel):
-    matrix: List[List[float]]
-    variables: List[str]
-    citations: List[str]
+    matrix: list[list[float]]
+    variables: list[str]
+    citations: list[str]
 
 
 class DomainKnowledge(BaseModel):
-    covariate_subsets: Optional[Dict[str, CovariateSubset]] = None
-    covariance_matrix: Optional[CovarianceMatrix] = None
+    covariate_subsets: dict[str, CovariateSubset] | None = None
+    covariance_matrix: CovarianceMatrix | None = None
 
 
 class ImputationConfig(BaseModel):
@@ -29,10 +29,10 @@ class ImputationConfig(BaseModel):
 
     model_config = {"arbitrary_types_allowed": True}
 
-    methods: List[str] = Field(..., description="Names of imputation methods")
-    modules: List[str] = Field(..., description="Python modules containing methods")
-    grids: List[ParameterGrid] = Field(..., description="Parameter grids for methods")
-    domain_knowledge: Optional[DomainKnowledge] = Field(
+    methods: list[str] = Field(..., description="Names of imputation methods")
+    modules: list[str] = Field(..., description="Python modules containing methods")
+    grids: list[ParameterGrid] = Field(..., description="Parameter grids for methods")
+    domain_knowledge: DomainKnowledge | None = Field(
         None, description="Domain knowledge for covariate imputation"
     )
 
@@ -42,4 +42,4 @@ class PreprocessingConfig(BaseModel):
 
     method: str
     module: str = "sklearn.preprocessing"
-    params: Dict[str, Any] = Field(default_factory=dict)
+    params: dict[str, Any] = Field(default_factory=dict)

--- a/phil/imputation/covariate_distribution.py
+++ b/phil/imputation/covariate_distribution.py
@@ -4,9 +4,9 @@ Covariate-conditional distribution imputation strategy.
 
 import numpy as np
 import pandas as pd
+from scipy.spatial.distance import cdist
 from sklearn.base import BaseEstimator
 from sklearn.metrics.pairwise import euclidean_distances
-from scipy.spatial.distance import cdist
 
 
 class CovariateDistributionImputer(BaseEstimator):

--- a/phil/magic/__init__.py
+++ b/phil/magic/__init__.py
@@ -6,4 +6,4 @@ from phil.magic.base import Magic
 from phil.magic.config import ECTConfig
 from phil.magic.ect import ECT
 
-__all__ = ["Magic", "ECT", "ECTConfig"]
+__all__ = ["ECT", "ECTConfig", "Magic"]

--- a/phil/magic/base.py
+++ b/phil/magic/base.py
@@ -3,7 +3,6 @@ Base interfaces for descriptor generation methods.
 """
 
 from abc import ABC, abstractmethod
-from typing import List
 
 import numpy as np
 from pydantic import BaseModel
@@ -14,5 +13,5 @@ class Magic(ABC):
         self.config = config
 
     @abstractmethod
-    def generate(self, data: List[np.ndarray]) -> List[np.ndarray]:
+    def generate(self, data: list[np.ndarray]) -> list[np.ndarray]:
         pass

--- a/phil/magic/ect.py
+++ b/phil/magic/ect.py
@@ -2,8 +2,6 @@
 Euler Characteristic Transform implementation backed by Rust.
 """
 
-from typing import List
-
 import numpy as np
 
 from . import rust_backend
@@ -23,14 +21,14 @@ class ECT(Magic):
             else:
                 raise ValueError(f"Invalid configuration key: {key}")
 
-    def generate(self, X: List[np.ndarray]) -> List[np.ndarray]:
+    def generate(self, X: list[np.ndarray]) -> list[np.ndarray]:
         if not isinstance(X, list):
-            raise ValueError("Input must be a list of numpy arrays")
+            raise TypeError("Input must be a list of numpy arrays")
         if not X or any(x.size == 0 for x in X):
             raise ValueError("Input cannot be empty")
 
         scale = float(self.scale)
-        descriptors: List[np.ndarray] = []
+        descriptors: list[np.ndarray] = []
         for sample in X:
             if np.ndim(sample) != 2:
                 raise ValueError("Each sample must be a 2D numpy array")

--- a/phil/mcp/config.py
+++ b/phil/mcp/config.py
@@ -655,5 +655,3 @@ def list_builtin_grids() -> list[dict[str, Any]]:
             )
         payload.append(entry)
     return payload
-
-

--- a/phil/mcp/config.py
+++ b/phil/mcp/config.py
@@ -138,17 +138,20 @@ def validate_config_yaml(
 
     try:
         raw = parse_yaml_mapping(config_yaml)
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         error_code = "YAML_NOT_RAW" if "raw YAML" in str(exc) else "CONFIG_YAML_INVALID"
+        agent_action = (
+            "Pass raw YAML only. Do not wrap config_yaml in Markdown fences."
+            if error_code == "YAML_NOT_RAW"
+            else "Pass a YAML mapping (key/value document), not a bare scalar or list."
+        )
         return ValidationReport(
             ok=False,
             normalized_yaml=None,
             resolved_dataset_path=dataset_path,
             issues=[ValidationIssue(path="$", message=str(exc))],
             error_code=error_code,
-            agent_action=(
-                "Pass raw YAML only. Do not wrap config_yaml in Markdown fences."
-            ),
+            agent_action=agent_action,
         )
 
     _validate_known_sections(raw, issues)

--- a/phil/mcp/config.py
+++ b/phil/mcp/config.py
@@ -19,7 +19,6 @@ from phil.gallery import GRID_METADATA, GridGallery
 from phil.imputation import ImputationConfig
 from phil.magic import ECTConfig
 
-
 # Derived from gallery.GRID_METADATA so MCP blurbs cannot drift from the
 # declarative metadata source of truth.
 GRID_INTENTS: dict[str, str] = {
@@ -90,7 +89,7 @@ def parse_yaml_mapping(config_yaml: str) -> dict[str, Any]:
         )
     parsed = yaml.safe_load(config_yaml)
     if not isinstance(parsed, dict):
-        raise ValueError("config_yaml must be a valid YAML mapping")
+        raise TypeError("config_yaml must be a valid YAML mapping")
     return parsed
 
 
@@ -313,27 +312,34 @@ def _validate_imputation(section: Any, issues: list[ValidationIssue]) -> None:
                     )
 
     for int_key in ("samples", "random_state", "max_iter"):
-        if int_key in section and section[int_key] is not None:
-            if not isinstance(section[int_key], int) or isinstance(
-                section[int_key], bool
-            ):
-                issues.append(
-                    ValidationIssue(
-                        path=f"$.imputation.{int_key}",
-                        message=f"'{int_key}' must be an integer.",
-                        received=section[int_key],
-                    )
-                )
-
-    if "samples" in section and isinstance(section["samples"], int):
-        if section["samples"] <= 0:
+        if (
+            int_key in section
+            and section[int_key] is not None
+            and (
+                not isinstance(section[int_key], int)
+                or isinstance(section[int_key], bool)
+            )
+        ):
             issues.append(
                 ValidationIssue(
-                    path="$.imputation.samples",
-                    message="'samples' must be > 0.",
-                    received=section["samples"],
+                    path=f"$.imputation.{int_key}",
+                    message=f"'{int_key}' must be an integer.",
+                    received=section[int_key],
                 )
             )
+
+    if (
+        "samples" in section
+        and isinstance(section["samples"], int)
+        and section["samples"] <= 0
+    ):
+        issues.append(
+            ValidationIssue(
+                path="$.imputation.samples",
+                message="'samples' must be > 0.",
+                received=section["samples"],
+            )
+        )
 
     if "drop_cols" in section and section["drop_cols"] is not None:
         drop_cols = section["drop_cols"]

--- a/phil/mcp/config.py
+++ b/phil/mcp/config.py
@@ -15,18 +15,15 @@ from typing import Any
 import yaml
 from sklearn.model_selection import ParameterGrid
 
-from phil.gallery import GridGallery
+from phil.gallery import GRID_METADATA, GridGallery
 from phil.imputation import ImputationConfig
 from phil.magic import ECTConfig
 
 
+# Derived from gallery.GRID_METADATA so MCP blurbs cannot drift from the
+# declarative metadata source of truth.
 GRID_INTENTS: dict[str, str] = {
-    "default": "Mixed regression imputers across BayesianRidge, Decision Tree, Random Forest, and Gradient Boosting.",
-    "sampling": "Distribution sampling imputation across 100 seeds (good for preserving marginals).",
-    "finance": "Iterative + KNN + Simple imputers tuned for tabular financial data.",
-    "healthcare": "KNN, Simple, and Iterative imputers tuned for clinical tables.",
-    "marketing": "Categorical-friendly Simple, KNN, and Iterative imputers.",
-    "engineering": "Robust mean/median + KNN + Decision-Tree iterative imputation for sensor data.",
+    name: meta.intent for name, meta in GRID_METADATA.items()
 }
 
 _ALLOWED_TOP_LEVEL = {"run", "imputation", "magic", "output"}
@@ -635,16 +632,28 @@ def config_to_phil_kwargs(config_yaml: str) -> dict[str, Any]:
 
 
 def list_builtin_grids() -> list[dict[str, Any]]:
-    """Return a list of built-in grid descriptions."""
+    """Return a list of built-in grid descriptions with declarative metadata."""
     payload: list[dict[str, Any]] = []
     for name in sorted(_BUILTIN_GRIDS):
         grid: ImputationConfig = GridGallery.get(name)
-        payload.append(
-            {
-                "name": name,
-                "intent": GRID_INTENTS.get(name, ""),
-                "methods": list(grid.methods),
-                "modules": list(grid.modules),
-            }
-        )
+        meta = GRID_METADATA.get(name)
+        entry: dict[str, Any] = {
+            "name": name,
+            "intent": GRID_INTENTS.get(name, ""),
+            "methods": list(grid.methods),
+            "modules": list(grid.modules),
+        }
+        if meta is not None:
+            entry.update(
+                {
+                    "target_domain": meta.target_domain,
+                    "suitability": meta.suitability,
+                    "data_type_affinity": list(meta.data_type_affinity),
+                    "time_complexity": meta.time_complexity,
+                    "scale_limits": meta.scale_limits,
+                }
+            )
+        payload.append(entry)
     return payload
+
+

--- a/phil/mcp/errors.py
+++ b/phil/mcp/errors.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from typing import Any
 
-
 _SANDBOX_PATH_PREFIXES = (
     "/home/claude",
     "/mnt/",

--- a/phil/mcp/prompts.py
+++ b/phil/mcp/prompts.py
@@ -28,26 +28,30 @@ that happens to converge.
    sweep — Phil cannot impute fully-empty features.
 
 ## PHASE II: CONFIGURE & VALIDATE
-4. Discover grids: `list_grids()` enumerates the named imputation grids
+4. Recommend a grid: `recommend_grid(dataset_id)` applies scale,
+   cardinality, and missingness heuristics and returns a concrete grid
+   plus suggested `samples`. Optionally read the MCP resource
+   `phil://docs/imputation-matrix` for the full comparison table.
+5. Discover grids: `list_grids()` enumerates the named imputation grids
    (`default`, `sampling`, `finance`, `healthcare`, `marketing`,
-   `engineering`) with their method lists. Pick the one whose intent
-   matches your dataset.
-5. Create the config: `create_config(dataset_id, grid="...")` returns a
+   `engineering`) with declarative metadata (intent, suitability,
+   affinity, time complexity, scale limits).
+6. Create the config: `create_config(dataset_id, grid="...")` returns a
    canonical YAML scaffold. You can refine it with `refine_config` or
    keep it in-session via `refine_active_config`.
-6. Validate: `validate_config(config_yaml, dataset_id)` confirms the
+7. Validate: `validate_config(config_yaml, dataset_id)` confirms the
    shape, resolves grid names, and normalizes whitespace.
 
 ## PHASE III: RUN, DIAGNOSE, EXPORT
-7. Run: `run_imputation_sweep` fits `samples` candidate imputations,
+8. Run: `run_imputation_sweep` fits `samples` candidate imputations,
    scores each with the ECT magic method, and selects the candidate
    closest to the mean descriptor. Returns a markdown diff against the
    previous run.
-8. Diagnose: `diagnose_sweep` reports descriptor spread, selected
+9. Diagnose: `diagnose_sweep` reports descriptor spread, selected
    candidate index, and per-method candidate counts. If spread is near
    zero the grid is collapsing — broaden it. If spread is huge,
    consider raising `samples`.
-9. Export: `export_imputed_data(run_id, output_path)` writes the chosen
+10. Export: `export_imputed_data(run_id, output_path)` writes the chosen
    imputed dataframe to disk (CSV or Parquet by file extension).
 
 ## PHILOSOPHY

--- a/phil/mcp/prompts.py
+++ b/phil/mcp/prompts.py
@@ -8,7 +8,6 @@ the opinionated workflow do not pay for it on every session.
 
 from __future__ import annotations
 
-
 WORKFLOW_PROMPT = """\
 # Phil Imputation Sweep Workflow
 

--- a/phil/mcp/recommend.py
+++ b/phil/mcp/recommend.py
@@ -1,0 +1,152 @@
+"""Rule-based imputation-grid recommender for MCP agents."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from phil.gallery import GRID_METADATA, get_grid_metadata
+
+_HIGH_CARDINALITY_UNIQUE = 50
+_LARGE_N_ROWS = 100_000
+_EXTREME_MISSING_PCT = 50.0
+
+
+def _is_categorical_series(series: pd.Series) -> bool:
+    return bool(
+        pd.api.types.is_object_dtype(series)
+        or pd.api.types.is_string_dtype(series)
+        or isinstance(series.dtype, pd.CategoricalDtype)
+    )
+
+
+def _frame_metrics(df: pd.DataFrame) -> dict[str, Any]:
+    n_rows = int(len(df))
+    n_cols = int(df.shape[1])
+    total_missing = int(df.isna().sum().sum())
+    overall_missing_pct = (
+        round(total_missing / (n_rows * n_cols) * 100, 3)
+        if n_rows and n_cols
+        else 0.0
+    )
+
+    categorical_columns: list[str] = []
+    high_cardinality_columns: list[str] = []
+    for col in df.columns:
+        series = df[col]
+        if not _is_categorical_series(series):
+            continue
+        name = str(col)
+        categorical_columns.append(name)
+        if int(series.nunique(dropna=True)) >= _HIGH_CARDINALITY_UNIQUE:
+            high_cardinality_columns.append(name)
+
+    return {
+        "n_rows": n_rows,
+        "n_cols": n_cols,
+        "total_missing": total_missing,
+        "overall_missing_pct": overall_missing_pct,
+        "n_categorical": len(categorical_columns),
+        "categorical_columns": categorical_columns,
+        "high_cardinality_columns": high_cardinality_columns,
+        "has_high_cardinality": bool(high_cardinality_columns),
+    }
+
+
+def _metadata_fields(grid_name: str) -> dict[str, Any]:
+    meta = get_grid_metadata(grid_name)
+    if meta is None:
+        # Should not happen for built-in recommendations; keep payload stable.
+        return {"name": grid_name}
+    return {
+        "name": meta.name,
+        "target_domain": meta.target_domain,
+        "intent": meta.intent,
+        "suitability": meta.suitability,
+        "data_type_affinity": list(meta.data_type_affinity),
+        "time_complexity": meta.time_complexity,
+        "scale_limits": meta.scale_limits,
+    }
+
+
+def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
+    """Choose a built-in grid from dataframe shape / missingness heuristics."""
+    metrics = _frame_metrics(df)
+    warnings: list[str] = []
+    rationale: list[str] = []
+
+    n_rows = metrics["n_rows"]
+    overall_missing_pct = metrics["overall_missing_pct"]
+    n_categorical = metrics["n_categorical"]
+    has_high_cardinality = metrics["has_high_cardinality"]
+
+    if n_rows > _LARGE_N_ROWS:
+        recommended = "sampling" if n_categorical == 0 else "default"
+        suggested_samples = 10
+        warnings.append(
+            "N > 100,000: avoid KNN-heavy grids (`healthcare`, `finance`) "
+            "unless you reduce samples or subsample rows."
+        )
+        rationale.append(
+            f"Large table ({n_rows:,} rows); prefer a lower-overhead grid "
+            f"(`{recommended}`) and keep samples modest."
+        )
+        if n_categorical == 0:
+            rationale.append(
+                "No categorical columns detected; `sampling` preserves "
+                "marginals without KNN quadratic cost."
+            )
+        else:
+            rationale.append(
+                "Categorical columns present; `default` is a safer mixed-type "
+                "starting point than KNN-heavy domain grids."
+            )
+    elif has_high_cardinality:
+        recommended = "marketing"
+        suggested_samples = 15
+        rationale.append(
+            "High-cardinality categorical columns detected "
+            f"({', '.join(metrics['high_cardinality_columns'][:5])}"
+            f"{'…' if len(metrics['high_cardinality_columns']) > 5 else ''}); "
+            "`marketing` pairs with TargetEncoder-friendly preprocessing."
+        )
+    elif overall_missing_pct > _EXTREME_MISSING_PCT:
+        recommended = "default"
+        suggested_samples = 20
+        warnings.append(
+            "Overall missingness > 50%: tree-based / iterative regressors may "
+            "struggle to converge; monitor diagnose_sweep spread and consider "
+            "dropping ultra-sparse columns."
+        )
+        rationale.append(
+            f"Extreme missingness ({overall_missing_pct}%); start with "
+            "`default` and a moderate sample budget."
+        )
+    else:
+        recommended = "default"
+        suggested_samples = 20
+        rationale.append(
+            "No scale, cardinality, or extreme-missingness flags; "
+            "`default` is the general-purpose starting grid."
+        )
+
+    # Defensive: every recommendation must exist in the declarative catalog.
+    if recommended not in GRID_METADATA:
+        recommended = "default"
+
+    recommendation = (
+        f"Recommended Grid: {recommended}, suggested samples: "
+        f"{suggested_samples} to preserve performance."
+    )
+
+    return {
+        "status": "ok",
+        "recommended_grid": recommended,
+        "suggested_samples": suggested_samples,
+        "recommendation": recommendation,
+        "warnings": warnings,
+        "rationale": rationale,
+        "metrics": metrics,
+        "grid": _metadata_fields(recommended),
+    }

--- a/phil/mcp/recommend.py
+++ b/phil/mcp/recommend.py
@@ -45,9 +45,7 @@ def _frame_metrics(df: pd.DataFrame) -> dict[str, Any]:
     n_cols = int(df.shape[1])
     total_missing = int(df.isna().sum().sum())
     overall_missing_pct = (
-        round(total_missing / (n_rows * n_cols) * 100, 3)
-        if n_rows and n_cols
-        else 0.0
+        round(total_missing / (n_rows * n_cols) * 100, 3) if n_rows and n_cols else 0.0
     )
 
     categorical_columns: list[str] = []

--- a/phil/mcp/recommend.py
+++ b/phil/mcp/recommend.py
@@ -45,7 +45,7 @@ def _is_high_cardinality_id(series: pd.Series, *, name: str, n_unique: int) -> b
 
 
 def _frame_metrics(df: pd.DataFrame) -> dict[str, Any]:
-    n_rows = int(len(df))
+    n_rows = len(df)
     n_cols = int(df.shape[1])
     total_missing = int(df.isna().sum().sum())
     overall_missing_pct = (
@@ -109,7 +109,7 @@ def _sample_budget(
     then cap by scalability (large N, KNN, sampling gallery).
     """
     fmi_proxy = missing_pct / 100.0
-    m_from_missing = max(_M_EFFICIENCY_FLOOR, int(math.ceil(100 * fmi_proxy)))
+    m_from_missing = max(_M_EFFICIENCY_FLOOR, math.ceil(100 * fmi_proxy))
     m_stability_uncapped = m_from_missing
     m_stability = min(m_from_missing, _M_STABILITY_CAP)
 
@@ -135,10 +135,14 @@ def _sample_budget(
         "suggested_samples": suggested,
         "literature_notes": [
             "Heuristic: start near 5 samples when missingness is low.",
-            "Raise samples roughly with overall % missing, then cap for "
-            "runtime (large N, KNN, or the sampling gallery).",
-            "Phil samples ≈ multiverse coverage of the candidate grid, "
-            "not classical MI pooling size m.",
+            (
+                "Raise samples roughly with overall % missing, then cap for "
+                "runtime (large N, KNN, or the sampling gallery)."
+            ),
+            (
+                "Phil samples ≈ multiverse coverage of the candidate grid, "
+                "not classical MI pooling size m."
+            ),
         ],
     }
 
@@ -150,7 +154,7 @@ def _subsample_advice(n_rows: int, has_knn: bool) -> dict[str, Any] | None:
     target = min(target, n_rows)
     return {
         "recommended": n_rows > target,
-        "suggested_rows": target if n_rows > target else n_rows,
+        "suggested_rows": min(n_rows, target),
         "reason": (
             "Subsample rows before KNN/iterative sweeps on large N; "
             "fit on the subset, then optionally refit the chosen method."

--- a/phil/mcp/recommend.py
+++ b/phil/mcp/recommend.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 import pandas as pd
 
-from phil.gallery import GRID_METADATA, get_grid_metadata
+from phil.gallery import GRID_METADATA, GridGallery, get_grid_metadata
 
 _HIGH_CARDINALITY_UNIQUE = 50
 _LARGE_N_ROWS = 100_000
 _EXTREME_MISSING_PCT = 50.0
+
+# Classical MI: a small m often suffices for point-estimate efficiency (Rubin).
+_M_EFFICIENCY_FLOOR = 5
+# Practical ceiling before Phil sweeps become an expensive multiverse.
+_M_STABILITY_CAP = 40
 
 
 def _is_categorical_series(series: pd.Series) -> bool:
@@ -22,7 +28,13 @@ def _is_categorical_series(series: pd.Series) -> bool:
 
 
 def _is_high_cardinality_id(series: pd.Series) -> bool:
-    """Integer columns with many distinct values behave like categorical IDs."""
+    """Integer ID columns with many distinct values (ZIP, product_id, …).
+
+    Only integer / nullable-integer dtypes qualify. Integral *floats*
+    (lab values like glucose after CSV+NA promotion) are measurements,
+    not categoricals — do not route them to ``marketing``.
+    Prefer pandas ``Int64`` for ID columns that may contain NA.
+    """
     if not pd.api.types.is_integer_dtype(series):
         return False
     return int(series.nunique(dropna=True)) >= _HIGH_CARDINALITY_UNIQUE
@@ -62,13 +74,15 @@ def _frame_metrics(df: pd.DataFrame) -> dict[str, Any]:
         "categorical_columns": categorical_columns,
         "high_cardinality_columns": high_cardinality_columns,
         "has_high_cardinality": bool(high_cardinality_columns),
+        # Proxy for Rubin's fraction of missing information (γ) when FMI
+        # is unavailable: overall cell-missing rate.
+        "fmi_proxy": round(overall_missing_pct / 100.0, 4),
     }
 
 
 def _metadata_fields(grid_name: str) -> dict[str, Any]:
     meta = get_grid_metadata(grid_name)
     if meta is None:
-        # Should not happen for built-in recommendations; keep payload stable.
         return {"name": grid_name}
     return {
         "name": meta.name,
@@ -79,6 +93,146 @@ def _metadata_fields(grid_name: str) -> dict[str, Any]:
         "time_complexity": meta.time_complexity,
         "scale_limits": meta.scale_limits,
     }
+
+
+def _grid_scalability(grid_name: str) -> dict[str, Any]:
+    """Expose candidate count / KNN risk so agents can budget compute."""
+    grid = GridGallery.get(grid_name)
+    methods = list(grid.methods)
+    n_candidates = sum(len(list(param_grid)) for param_grid in grid.grids)
+    has_knn = any("KNN" in method for method in methods)
+    has_iterative = any("Iterative" in method for method in methods)
+    has_tree_ensemble = any(
+        method
+        in {
+            "RandomForestRegressor",
+            "GradientBoostingRegressor",
+            "ExtraTreesRegressor",
+        }
+        for method in methods
+    )
+    if has_knn:
+        big_o = "O(N^2) neighbor search dominates when KNN is in the grid"
+        cost_tier = "high" if n_candidates >= 7 else "medium_high"
+    elif has_tree_ensemble:
+        big_o = "O(N log N · trees) per iterative/ensemble fit"
+        cost_tier = "medium"
+    elif has_iterative:
+        big_o = "O(N · P · iters) chained / iterative updates"
+        cost_tier = "medium"
+    else:
+        big_o = "Near-linear in N for simple / distributional imputers"
+        cost_tier = "low"
+
+    return {
+        "grid_candidate_count": n_candidates,
+        "methods": methods,
+        "has_knn": has_knn,
+        "has_iterative": has_iterative,
+        "has_tree_ensemble": has_tree_ensemble,
+        "cost_tier": cost_tier,
+        "complexity_note": big_o,
+    }
+
+
+def _literature_sample_budget(
+    *,
+    n_rows: int,
+    missing_pct: float,
+    has_knn: bool,
+    grid_name: str,
+) -> dict[str, Any]:
+    """Map MI literature onto Phil's ensemble ``samples`` knob.
+
+    Anchors:
+    - Rubin: small m (≈3–10) often enough for point-estimate efficiency.
+    - White / Bodner / von Hippel: larger m as FMI grows if you care about
+      stable SEs; a common practical rule is m on the order of % missing.
+    - Phil ``samples`` covers a multiverse of candidates (not Rubin's rules
+      pooling), so we still raise m with missingness, then cap by scalability
+      (large N, KNN).
+    """
+    fmi_proxy = missing_pct / 100.0
+    m_stability = max(_M_EFFICIENCY_FLOOR, int(math.ceil(100 * fmi_proxy)))
+    m_stability = min(m_stability, _M_STABILITY_CAP)
+
+    if n_rows > _LARGE_N_ROWS:
+        scalability_cap = 8 if has_knn else 12
+    elif n_rows > 20_000:
+        scalability_cap = 10 if has_knn else 20
+    elif has_knn:
+        scalability_cap = 15
+    else:
+        scalability_cap = 30
+
+    # The sampling gallery already expands ~100 seeds; keep Phil.samples modest.
+    if grid_name == "sampling":
+        scalability_cap = min(scalability_cap, 12)
+
+    suggested = int(min(m_stability, scalability_cap))
+    return {
+        "fmi_proxy": round(fmi_proxy, 4),
+        "m_efficiency_floor": _M_EFFICIENCY_FLOOR,
+        "m_stability_uncapped": min(
+            max(_M_EFFICIENCY_FLOOR, int(math.ceil(100 * fmi_proxy))),
+            _M_STABILITY_CAP,
+        ),
+        "scalability_cap": scalability_cap,
+        "suggested_samples": suggested,
+        "literature_notes": [
+            "Rubin MI: m≈5 often enough for point-estimate efficiency.",
+            "White/Bodner/von Hippel: increase m with FMI for stable SEs; "
+            "practical rule m ≈ percent missing (capped).",
+            "Phil samples ≈ multiverse coverage of the candidate grid; "
+            "cap further when N is large or KNN is present.",
+        ],
+    }
+
+
+def _subsample_advice(n_rows: int, has_knn: bool) -> dict[str, Any] | None:
+    if n_rows <= _LARGE_N_ROWS and not (has_knn and n_rows > 20_000):
+        return None
+    target = 50_000 if has_knn else 100_000
+    target = min(target, n_rows)
+    return {
+        "recommended": n_rows > target,
+        "suggested_rows": target if n_rows > target else n_rows,
+        "reason": (
+            "Subsample rows before KNN/iterative sweeps on large N; "
+            "fit on the subset, then optionally refit the chosen method."
+            if has_knn
+            else "Large N: consider a representative subsample for the sweep, "
+            "then apply the selected imputer to the full frame."
+        ),
+    }
+
+
+def _scalable_alternatives(recommended: str, n_rows: int) -> list[dict[str, Any]]:
+    """Cheaper grids an agent can fall back to when compute is tight."""
+    alts: list[str] = []
+    if recommended in {"healthcare", "finance", "marketing", "engineering"}:
+        alts.extend(["default", "sampling"])
+    elif recommended == "default" and n_rows > _LARGE_N_ROWS:
+        alts.append("sampling")
+    elif recommended == "sampling":
+        alts.append("default")
+
+    out: list[dict[str, Any]] = []
+    for name in alts:
+        if name == recommended or name not in GRID_METADATA:
+            continue
+        scale = _grid_scalability(name)
+        meta = _metadata_fields(name)
+        out.append(
+            {
+                "grid": name,
+                "cost_tier": scale["cost_tier"],
+                "has_knn": scale["has_knn"],
+                "grid_candidate_count": scale["grid_candidate_count"],
+                "why": meta.get("suitability", ""),
+            }
+        )
+    return out
 
 
 def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
@@ -94,7 +248,6 @@ def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
 
     if n_rows > _LARGE_N_ROWS:
         recommended = "sampling" if n_categorical == 0 else "default"
-        suggested_samples = 10
         warnings.append(
             "N > 100,000: avoid KNN-heavy grids (`healthcare`, `finance`) "
             "unless you reduce samples or subsample rows."
@@ -115,7 +268,6 @@ def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
             )
     elif has_high_cardinality:
         recommended = "marketing"
-        suggested_samples = 15
         rationale.append(
             "High-cardinality categorical columns detected "
             f"({', '.join(metrics['high_cardinality_columns'][:5])}"
@@ -124,7 +276,6 @@ def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
         )
     elif overall_missing_pct > _EXTREME_MISSING_PCT:
         recommended = "default"
-        suggested_samples = 20
         warnings.append(
             "Overall missingness > 50%: tree-based / iterative regressors may "
             "struggle to converge; monitor diagnose_sweep spread and consider "
@@ -132,19 +283,40 @@ def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
         )
         rationale.append(
             f"Extreme missingness ({overall_missing_pct}%); start with "
-            "`default` and a moderate sample budget."
+            "`default` and raise samples with FMI (literature-guided)."
         )
     else:
         recommended = "default"
-        suggested_samples = 20
         rationale.append(
             "No scale, cardinality, or extreme-missingness flags; "
             "`default` is the general-purpose starting grid."
         )
 
-    # Defensive: every recommendation must exist in the declarative catalog.
     if recommended not in GRID_METADATA:
         recommended = "default"
+
+    scalability = _grid_scalability(recommended)
+    sample_budget = _literature_sample_budget(
+        n_rows=n_rows,
+        missing_pct=overall_missing_pct,
+        has_knn=bool(scalability["has_knn"]),
+        grid_name=recommended,
+    )
+    suggested_samples = int(sample_budget["suggested_samples"])
+    subsample = _subsample_advice(n_rows, bool(scalability["has_knn"]))
+    alternatives = _scalable_alternatives(recommended, n_rows)
+
+    if scalability["has_knn"] and n_rows > 20_000:
+        warnings.append(
+            "Recommended grid includes KNN (≈O(N²)); prefer subsampling or "
+            "switch to a low-cost alternative if the sweep is slow."
+        )
+
+    rationale.append(
+        "Sample budget from MI literature (efficiency floor m≈5; raise with "
+        f"FMI proxy={sample_budget['fmi_proxy']}) then cap for scalability "
+        f"(cap={sample_budget['scalability_cap']})."
+    )
 
     recommendation = (
         f"Recommended Grid: {recommended}, suggested samples: "
@@ -160,4 +332,8 @@ def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
         "rationale": rationale,
         "metrics": metrics,
         "grid": _metadata_fields(recommended),
+        "scalability": scalability,
+        "sample_budget": sample_budget,
+        "subsample": subsample,
+        "scalable_alternatives": alternatives,
     }

--- a/phil/mcp/recommend.py
+++ b/phil/mcp/recommend.py
@@ -21,6 +21,13 @@ def _is_categorical_series(series: pd.Series) -> bool:
     )
 
 
+def _is_high_cardinality_id(series: pd.Series) -> bool:
+    """Integer columns with many distinct values behave like categorical IDs."""
+    if not pd.api.types.is_integer_dtype(series):
+        return False
+    return int(series.nunique(dropna=True)) >= _HIGH_CARDINALITY_UNIQUE
+
+
 def _frame_metrics(df: pd.DataFrame) -> dict[str, Any]:
     n_rows = int(len(df))
     n_cols = int(df.shape[1])
@@ -35,11 +42,15 @@ def _frame_metrics(df: pd.DataFrame) -> dict[str, Any]:
     high_cardinality_columns: list[str] = []
     for col in df.columns:
         series = df[col]
-        if not _is_categorical_series(series):
-            continue
         name = str(col)
-        categorical_columns.append(name)
-        if int(series.nunique(dropna=True)) >= _HIGH_CARDINALITY_UNIQUE:
+        n_unique = int(series.nunique(dropna=True))
+        if _is_categorical_series(series):
+            categorical_columns.append(name)
+            if n_unique >= _HIGH_CARDINALITY_UNIQUE:
+                high_cardinality_columns.append(name)
+        elif _is_high_cardinality_id(series):
+            # ZIP / product-id style ints: categorical for grid choice.
+            categorical_columns.append(name)
             high_cardinality_columns.append(name)
 
     return {

--- a/phil/mcp/recommend.py
+++ b/phil/mcp/recommend.py
@@ -3,20 +3,24 @@
 from __future__ import annotations
 
 import math
+import re
 from typing import Any
 
 import pandas as pd
 
-from phil.gallery import GRID_METADATA, GridGallery, get_grid_metadata
+from phil.gallery import GRID_METADATA, get_grid_metadata, grid_scalability
 
 _HIGH_CARDINALITY_UNIQUE = 50
 _LARGE_N_ROWS = 100_000
 _EXTREME_MISSING_PCT = 50.0
 
-# Classical MI: a small m often suffices for point-estimate efficiency (Rubin).
+# Floor for Phil.samples when missingness is low.
 _M_EFFICIENCY_FLOOR = 5
-# Practical ceiling before Phil sweeps become an expensive multiverse.
-_M_STABILITY_CAP = 40
+# Matches the highest non-KNN scalability_cap below.
+_M_STABILITY_CAP = 30
+
+# Integer columns only count as IDs when the name looks ID-like.
+_ID_NAME_RE = re.compile(r"(?i)(^id$|_id$|^zip(_|$)|_code$|^code$)")
 
 
 def _is_categorical_series(series: pd.Series) -> bool:
@@ -27,17 +31,17 @@ def _is_categorical_series(series: pd.Series) -> bool:
     )
 
 
-def _is_high_cardinality_id(series: pd.Series) -> bool:
-    """Integer ID columns with many distinct values (ZIP, product_id, …).
+def _is_high_cardinality_id(series: pd.Series, *, name: str, n_unique: int) -> bool:
+    """Integer ID columns (ZIP, product_id, …), not ordinary measurements.
 
-    Only integer / nullable-integer dtypes qualify. Integral *floats*
-    (lab values like glucose after CSV+NA promotion) are measurements,
-    not categoricals — do not route them to ``marketing``.
-    Prefer pandas ``Int64`` for ID columns that may contain NA.
+    Requires an ID-like column name plus high cardinality. Raw uniqueness
+    alone misroutes ``salary`` / ``age``-style integer measurements.
     """
     if not pd.api.types.is_integer_dtype(series):
         return False
-    return int(series.nunique(dropna=True)) >= _HIGH_CARDINALITY_UNIQUE
+    if n_unique < _HIGH_CARDINALITY_UNIQUE:
+        return False
+    return bool(_ID_NAME_RE.search(name))
 
 
 def _frame_metrics(df: pd.DataFrame) -> dict[str, Any]:
@@ -47,6 +51,13 @@ def _frame_metrics(df: pd.DataFrame) -> dict[str, Any]:
     overall_missing_pct = (
         round(total_missing / (n_rows * n_cols) * 100, 3) if n_rows and n_cols else 0.0
     )
+    if n_rows and n_cols:
+        col_missing_pct = df.isna().mean() * 100.0
+        max_col_missing_pct = float(round(col_missing_pct.max(), 3))
+        n_sparse_cols = int((col_missing_pct > _EXTREME_MISSING_PCT).sum())
+    else:
+        max_col_missing_pct = 0.0
+        n_sparse_cols = 0
 
     categorical_columns: list[str] = []
     high_cardinality_columns: list[str] = []
@@ -58,8 +69,7 @@ def _frame_metrics(df: pd.DataFrame) -> dict[str, Any]:
             categorical_columns.append(name)
             if n_unique >= _HIGH_CARDINALITY_UNIQUE:
                 high_cardinality_columns.append(name)
-        elif _is_high_cardinality_id(series):
-            # ZIP / product-id style ints: categorical for grid choice.
+        elif _is_high_cardinality_id(series, name=name, n_unique=n_unique):
             categorical_columns.append(name)
             high_cardinality_columns.append(name)
 
@@ -68,12 +78,12 @@ def _frame_metrics(df: pd.DataFrame) -> dict[str, Any]:
         "n_cols": n_cols,
         "total_missing": total_missing,
         "overall_missing_pct": overall_missing_pct,
+        "max_col_missing_pct": max_col_missing_pct,
+        "n_sparse_cols": n_sparse_cols,
         "n_categorical": len(categorical_columns),
         "categorical_columns": categorical_columns,
         "high_cardinality_columns": high_cardinality_columns,
         "has_high_cardinality": bool(high_cardinality_columns),
-        # Proxy for Rubin's fraction of missing information (γ) when FMI
-        # is unavailable: overall cell-missing rate.
         "fmi_proxy": round(overall_missing_pct / 100.0, 4),
     }
 
@@ -82,77 +92,26 @@ def _metadata_fields(grid_name: str) -> dict[str, Any]:
     meta = get_grid_metadata(grid_name)
     if meta is None:
         return {"name": grid_name}
-    return {
-        "name": meta.name,
-        "target_domain": meta.target_domain,
-        "intent": meta.intent,
-        "suitability": meta.suitability,
-        "data_type_affinity": list(meta.data_type_affinity),
-        "time_complexity": meta.time_complexity,
-        "scale_limits": meta.scale_limits,
-    }
+    return meta.to_dict()
 
 
-def _grid_scalability(grid_name: str) -> dict[str, Any]:
-    """Expose candidate count / KNN risk so agents can budget compute."""
-    grid = GridGallery.get(grid_name)
-    methods = list(grid.methods)
-    n_candidates = sum(len(list(param_grid)) for param_grid in grid.grids)
-    has_knn = any("KNN" in method for method in methods)
-    has_iterative = any("Iterative" in method for method in methods)
-    has_tree_ensemble = any(
-        method
-        in {
-            "RandomForestRegressor",
-            "GradientBoostingRegressor",
-            "ExtraTreesRegressor",
-        }
-        for method in methods
-    )
-    if has_knn:
-        big_o = "O(N^2) neighbor search dominates when KNN is in the grid"
-        cost_tier = "high" if n_candidates >= 7 else "medium_high"
-    elif has_tree_ensemble:
-        big_o = "O(N log N · trees) per iterative/ensemble fit"
-        cost_tier = "medium"
-    elif has_iterative:
-        big_o = "O(N · P · iters) chained / iterative updates"
-        cost_tier = "medium"
-    else:
-        big_o = "Near-linear in N for simple / distributional imputers"
-        cost_tier = "low"
-
-    return {
-        "grid_candidate_count": n_candidates,
-        "methods": methods,
-        "has_knn": has_knn,
-        "has_iterative": has_iterative,
-        "has_tree_ensemble": has_tree_ensemble,
-        "cost_tier": cost_tier,
-        "complexity_note": big_o,
-    }
-
-
-def _literature_sample_budget(
+def _sample_budget(
     *,
     n_rows: int,
     missing_pct: float,
     has_knn: bool,
     grid_name: str,
 ) -> dict[str, Any]:
-    """Map MI literature onto Phil's ensemble ``samples`` knob.
+    """Heuristic Phil ``samples`` budget from missingness and grid cost.
 
-    Anchors:
-    - Rubin: small m (≈3–10) often enough for point-estimate efficiency.
-    - White / Bodner / von Hippel: larger m as FMI grows if you care about
-      stable SEs; a common practical rule is m on the order of % missing.
-    - Phil ``samples`` covers a multiverse of candidates (not Rubin's rules
-      pooling), so we still raise m with missingness, then cap by scalability
-      (large N, KNN).
+    Phil ``samples`` is multiverse coverage of the candidate grid, not Rubin's
+    multiple-imputation *m*. We still raise the budget with cell-missing rate,
+    then cap by scalability (large N, KNN, sampling gallery).
     """
     fmi_proxy = missing_pct / 100.0
-    m_stability = max(_M_EFFICIENCY_FLOOR, int(math.ceil(100 * fmi_proxy)))
-    m_stability = min(m_stability, _M_STABILITY_CAP)
+    m_from_missing = max(_M_EFFICIENCY_FLOOR, int(math.ceil(100 * fmi_proxy)))
+    m_stability_uncapped = m_from_missing
+    m_stability = min(m_from_missing, _M_STABILITY_CAP)
 
     if n_rows > _LARGE_N_ROWS:
         scalability_cap = 8 if has_knn else 12
@@ -171,18 +130,15 @@ def _literature_sample_budget(
     return {
         "fmi_proxy": round(fmi_proxy, 4),
         "m_efficiency_floor": _M_EFFICIENCY_FLOOR,
-        "m_stability_uncapped": min(
-            max(_M_EFFICIENCY_FLOOR, int(math.ceil(100 * fmi_proxy))),
-            _M_STABILITY_CAP,
-        ),
+        "m_stability_uncapped": m_stability_uncapped,
         "scalability_cap": scalability_cap,
         "suggested_samples": suggested,
         "literature_notes": [
-            "Rubin MI: m≈5 often enough for point-estimate efficiency.",
-            "White/Bodner/von Hippel: increase m with FMI for stable SEs; "
-            "practical rule m ≈ percent missing (capped).",
-            "Phil samples ≈ multiverse coverage of the candidate grid; "
-            "cap further when N is large or KNN is present.",
+            "Heuristic: start near 5 samples when missingness is low.",
+            "Raise samples roughly with overall % missing, then cap for "
+            "runtime (large N, KNN, or the sampling gallery).",
+            "Phil samples ≈ multiverse coverage of the candidate grid, "
+            "not classical MI pooling size m.",
         ],
     }
 
@@ -219,7 +175,7 @@ def _scalable_alternatives(recommended: str, n_rows: int) -> list[dict[str, Any]
     for name in alts:
         if name == recommended or name not in GRID_METADATA:
             continue
-        scale = _grid_scalability(name)
+        scale = grid_scalability(name)
         meta = _metadata_fields(name)
         out.append(
             {
@@ -241,6 +197,7 @@ def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
 
     n_rows = metrics["n_rows"]
     overall_missing_pct = metrics["overall_missing_pct"]
+    max_col_missing_pct = metrics["max_col_missing_pct"]
     n_categorical = metrics["n_categorical"]
     has_high_cardinality = metrics["has_high_cardinality"]
 
@@ -270,18 +227,13 @@ def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
             "High-cardinality categorical columns detected "
             f"({', '.join(metrics['high_cardinality_columns'][:5])}"
             f"{'…' if len(metrics['high_cardinality_columns']) > 5 else ''}); "
-            "`marketing` pairs with TargetEncoder-friendly preprocessing."
+            "`marketing` targets high-cardinality / mixed consumer tables."
         )
-    elif overall_missing_pct > _EXTREME_MISSING_PCT:
+    elif max_col_missing_pct > _EXTREME_MISSING_PCT:
         recommended = "default"
-        warnings.append(
-            "Overall missingness > 50%: tree-based / iterative regressors may "
-            "struggle to converge; monitor diagnose_sweep spread and consider "
-            "dropping ultra-sparse columns."
-        )
         rationale.append(
-            f"Extreme missingness ({overall_missing_pct}%); start with "
-            "`default` and raise samples with FMI (literature-guided)."
+            f"Extreme per-column missingness (max {max_col_missing_pct}%); "
+            "start with `default` and raise samples with missingness."
         )
     else:
         recommended = "default"
@@ -290,11 +242,23 @@ def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
             "`default` is the general-purpose starting grid."
         )
 
+    # Warnings accumulate independently of which branch picked the grid.
+    if (
+        max_col_missing_pct > _EXTREME_MISSING_PCT
+        or metrics["n_sparse_cols"] > 0
+        or overall_missing_pct > _EXTREME_MISSING_PCT
+    ):
+        warnings.append(
+            "Column(s) with >50% missing: tree-based / iterative regressors may "
+            "struggle to converge; monitor diagnose_sweep spread and consider "
+            "dropping ultra-sparse columns."
+        )
+
     if recommended not in GRID_METADATA:
         recommended = "default"
 
-    scalability = _grid_scalability(recommended)
-    sample_budget = _literature_sample_budget(
+    scalability = grid_scalability(recommended)
+    sample_budget = _sample_budget(
         n_rows=n_rows,
         missing_pct=overall_missing_pct,
         has_knn=bool(scalability["has_knn"]),
@@ -311,8 +275,8 @@ def recommend_grid_for_dataframe(df: pd.DataFrame) -> dict[str, Any]:
         )
 
     rationale.append(
-        "Sample budget from MI literature (efficiency floor m≈5; raise with "
-        f"FMI proxy={sample_budget['fmi_proxy']}) then cap for scalability "
+        "Sample budget heuristic (floor≈5; raise with missingness proxy="
+        f"{sample_budget['fmi_proxy']}) then cap for scalability "
         f"(cap={sample_budget['scalability_cap']})."
     )
 

--- a/phil/mcp/registry.py
+++ b/phil/mcp/registry.py
@@ -14,7 +14,6 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-
 _CACHE_DIR = Path(tempfile.gettempdir()) / "phil_mcp"
 _DATASETS_PATH = _CACHE_DIR / "datasets.json"
 _DATASET_FILES_DIR = _CACHE_DIR / "datasets"
@@ -88,7 +87,7 @@ class MCPRegistry:
         resolved = Path(path).expanduser().resolve(strict=True)
         stat = resolved.stat()
         digest = hashlib.sha256(
-            f"{resolved}:{stat.st_size}:{stat.st_mtime_ns}".encode("utf-8")
+            f"{resolved}:{stat.st_size}:{stat.st_mtime_ns}".encode()
         ).hexdigest()[:12]
         record = DatasetRecord(
             dataset_id=f"ds_{digest}",
@@ -263,13 +262,12 @@ class MCPRegistry:
 
     @contextmanager
     def _locked_registry(self):
-        with _PROCESS_LOCK:
-            with _LOCK_PATH.open("a+b") as handle:
-                self._acquire_file_lock(handle)
-                try:
-                    yield
-                finally:
-                    self._release_file_lock(handle)
+        with _PROCESS_LOCK, _LOCK_PATH.open("a+b") as handle:
+            self._acquire_file_lock(handle)
+            try:
+                yield
+            finally:
+                self._release_file_lock(handle)
 
     @staticmethod
     def _acquire_file_lock(handle) -> None:

--- a/phil/mcp/server.py
+++ b/phil/mcp/server.py
@@ -106,6 +106,7 @@ mcp = FastMCP(
     ),
 )
 
+
 @mcp.resource(
     "phil://docs/imputation-matrix",
     mime_type="text/markdown",

--- a/phil/mcp/server.py
+++ b/phil/mcp/server.py
@@ -27,6 +27,7 @@ import yaml
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 
+from phil.gallery import render_imputation_matrix
 from phil.mcp.config import (
     GRID_INTENTS,
     apply_overrides,
@@ -38,6 +39,7 @@ from phil.mcp.config import (
 )
 from phil.mcp.errors import mcp_error, path_access_error, unknown_handle_error
 from phil.mcp.prompts import WORKFLOW_PROMPT
+from phil.mcp.recommend import recommend_grid_for_dataframe
 from phil.mcp.registry import MCPRegistry
 from phil.phil import Phil
 
@@ -94,14 +96,28 @@ mcp = FastMCP(
         "`finalize_dataset_upload` trio for sandboxed clients. Returns a "
         "`dataset_id` handle. Polars users: write to Parquet, then ingest.\n"
         "- Characterize: `characterize_dataset`, `probe_columns`.\n"
-        "- Configure: `list_grids`, `create_config`, `validate_config`, "
-        "`refine_config`, `get_active_config`, `refine_active_config`.\n"
+        "- Configure: `recommend_grid`, `list_grids`, `create_config`, "
+        "`validate_config`, `refine_config`, `get_active_config`, "
+        "`refine_active_config`. Resource: `phil://docs/imputation-matrix`.\n"
         "- Run: `run_imputation_sweep`.\n"
         "- Diagnose: `diagnose_sweep`, `get_candidate_descriptors`, "
         "`compare_sweeps`, `get_experiment_history`.\n"
         "- Export: `get_sweep_summary`, `export_imputed_data`."
     ),
 )
+
+@mcp.resource(
+    "phil://docs/imputation-matrix",
+    mime_type="text/markdown",
+    description=(
+        "Markdown comparison matrix of built-in imputation grids: domain, "
+        "complexity, affinity, scale limits, and estimator cost notes. "
+        "Compiled from declarative GRID_METADATA."
+    ),
+)
+def imputation_matrix_resource() -> str:
+    """Return the dynamically compiled imputation-grid comparison matrix."""
+    return render_imputation_matrix()
 
 
 # ---------------------------------------------------------------------------
@@ -785,6 +801,36 @@ async def list_grids(ctx: Context = None) -> str:
         return json.dumps(payload, indent=2)
     except Exception as e:
         return mcp_error("list_grids", str(e))
+
+
+@mcp.tool()
+async def recommend_grid(
+    dataset_id: str = "",
+    data_path: str = "",
+    ctx: Context = None,
+) -> str:
+    """
+    Recommend a built-in imputation grid from dataset scale, categorical
+    cardinality, and missingness heuristics. Prefer this after
+    ``characterize_dataset`` and before ``create_config``.
+    """
+    try:
+        session = _get_session(ctx)
+        df, normalized_path = await _load_session_dataframe(
+            session, dataset_id=dataset_id, data_path=data_path
+        )
+        payload = recommend_grid_for_dataframe(df)
+        payload["dataset_id"] = dataset_id or None
+        payload["data_path"] = normalized_path
+        return json.dumps(payload, indent=2)
+    except LookupError:
+        return unknown_handle_error("recommend_grid", "dataset_id", dataset_id)
+    except FileNotFoundError:
+        return path_access_error("recommend_grid", data_path or dataset_id)
+    except ToolError as e:
+        return mcp_error("recommend_grid", str(e))
+    except Exception as e:
+        return mcp_error("recommend_grid", str(e))
 
 
 @mcp.tool()

--- a/phil/mcp/server.py
+++ b/phil/mcp/server.py
@@ -43,7 +43,6 @@ from phil.mcp.recommend import recommend_grid_for_dataframe
 from phil.mcp.registry import MCPRegistry
 from phil.phil import Phil
 
-
 logger = logging.getLogger(__name__)
 registry = MCPRegistry()
 
@@ -56,7 +55,7 @@ registry = MCPRegistry()
 # known orchestration keys *before* validation — one patch protects every
 # tool. Unknown keys outside the allowlist are logged at WARNING.
 # ---------------------------------------------------------------------------
-from fastmcp.tools.function_tool import FunctionTool  # noqa: E402
+from fastmcp.tools.function_tool import FunctionTool
 
 _original_function_tool_run = FunctionTool.run
 _KNOWN_ORCHESTRATION_KEYS = frozenset({"wait_for_previous"})
@@ -215,9 +214,9 @@ def _normalize_data_path(path: str) -> str:
 def _read_dataset_file(path: str) -> pd.DataFrame:
     normalized_path = _normalize_data_path(path)
     lowered = normalized_path.lower()
-    if lowered.endswith(".parquet") or lowered.endswith(".pq"):
+    if lowered.endswith((".parquet", ".pq")):
         return pd.read_parquet(normalized_path)
-    if lowered.endswith(".feather") or lowered.endswith(".arrow"):
+    if lowered.endswith((".feather", ".arrow")):
         return pd.read_feather(normalized_path)
     return pd.read_csv(normalized_path)
 
@@ -397,11 +396,15 @@ async def get_runtime_context(ctx: Context = None) -> str:
         "path_guidance": [
             "Use ingest_dataset(path) for host-visible absolute paths.",
             "Polars users: write to Parquet (`df.write_parquet(...)`), then ingest the path.",
-            "SANDBOX ISOLATION: If your file is in a sandbox (e.g. /home/claude), "
-            "use the 'Cache-Bridge' pattern: Copy the file to the `cache_dir` shown "
-            "above, then call `ingest_dataset(path)` on the destination.",
-            "Chunked/Base64 uploads are a last-resort legacy fallback for remote-only "
-            "servers. DO NOT use them for local files.",
+            (
+                "SANDBOX ISOLATION: If your file is in a sandbox (e.g. /home/claude), "
+                "use the 'Cache-Bridge' pattern: Copy the file to the `cache_dir` shown "
+                "above, then call `ingest_dataset(path)` on the destination."
+            ),
+            (
+                "Chunked/Base64 uploads are a last-resort legacy fallback for remote-only "
+                "servers. DO NOT use them for local files."
+            ),
         ],
     }
     return json.dumps(payload, indent=2)
@@ -445,7 +448,7 @@ async def ingest_dataset(path: str, ctx: Context = None) -> str:
             agent_action="Provide a readable host-visible dataset path.",
             details={"path_context": {"attempted_path": path}},
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("ingest_dataset", str(e))
 
 
@@ -463,7 +466,7 @@ async def begin_dataset_upload(
     try:
         record = registry.begin_upload(filename, media_type=media_type)
         return json.dumps(dataclasses.asdict(record), indent=2)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("begin_dataset_upload", str(e))
 
 
@@ -482,7 +485,7 @@ async def append_dataset_chunk(
         if encoding == "base64":
             try:
                 chunk_bytes = base64.b64decode(chunk, validate=True)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 return mcp_error(
                     "append_dataset_chunk",
                     "Failed to decode base64 chunk payload.",
@@ -504,7 +507,7 @@ async def append_dataset_chunk(
         if record is None:
             return unknown_handle_error("append_dataset_chunk", "upload_id", upload_id)
         return json.dumps(dataclasses.asdict(record), indent=2)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("append_dataset_chunk", str(e))
 
 
@@ -523,7 +526,7 @@ async def finalize_dataset_upload(upload_id: str, ctx: Context = None) -> str:
         session = _get_session(ctx)
         session.dataset_id = record.dataset_id
         return json.dumps(dataclasses.asdict(record), indent=2)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("finalize_dataset_upload", str(e))
 
 
@@ -546,7 +549,7 @@ async def characterize_dataset(
         df, normalized_path = await _load_session_dataframe(
             session, dataset_id=dataset_id, data_path=data_path
         )
-        n_rows = int(len(df))
+        n_rows = len(df)
         n_cols = int(df.shape[1])
         column_profiles: list[dict[str, Any]] = []
         for col in df.columns:
@@ -585,7 +588,7 @@ async def characterize_dataset(
         return path_access_error("characterize_dataset", data_path or dataset_id)
     except ToolError as e:
         return mcp_error("characterize_dataset", str(e))
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("characterize_dataset", str(e))
 
 
@@ -655,7 +658,7 @@ async def probe_columns(
         )
     except LookupError:
         return unknown_handle_error("probe_columns", "dataset_id", dataset_id)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("probe_columns", str(e))
 
 
@@ -800,7 +803,7 @@ async def list_grids(ctx: Context = None) -> str:
             ),
         }
         return json.dumps(payload, indent=2)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("list_grids", str(e))
 
 
@@ -828,7 +831,7 @@ async def recommend_grid(
         return unknown_handle_error("recommend_grid", "dataset_id", dataset_id)
     except FileNotFoundError:
         return path_access_error("recommend_grid", data_path or dataset_id)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("recommend_grid", str(e))
 
 
@@ -889,7 +892,7 @@ async def create_config(
         return json.dumps(payload, indent=2)
     except LookupError:
         return unknown_handle_error("create_config", "dataset_id", dataset_id)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("create_config", str(e))
 
 
@@ -911,7 +914,7 @@ async def validate_config(
         return render_validation_report(report)
     except LookupError:
         return unknown_handle_error("validate_config", "dataset_id", dataset_id)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("validate_config", str(e))
 
 
@@ -944,7 +947,7 @@ async def refine_config(
                 "Use only valid override keys. See error message for the valid list."
             ),
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("refine_config", str(e))
 
 
@@ -1000,7 +1003,7 @@ async def refine_active_config(overrides: dict[str, Any], ctx: Context = None) -
                 "Use only valid override keys. See error message for the valid list."
             ),
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("refine_active_config", str(e))
 
 
@@ -1039,8 +1042,7 @@ async def run_imputation_sweep(
                 _validate_config_path(config_path)
             except FileNotFoundError:
                 return path_access_error("run_imputation_sweep", config_path)
-            with open(config_path) as f:
-                current_yaml = f.read()
+            current_yaml = Path(config_path).read_text()
         elif session.active_config_yaml:
             current_yaml = session.active_config_yaml
         else:
@@ -1103,7 +1105,7 @@ async def run_imputation_sweep(
                 error_code="NO_MISSING_VALUES",
                 agent_action="Pass a dataset containing missing values, or skip imputation.",
                 details={
-                    "n_rows": int(len(prepared_df)),
+                    "n_rows": len(prepared_df),
                     "n_cols": int(prepared_df.shape[1]),
                     "dropped_columns": dropped_columns,
                 },
@@ -1132,10 +1134,7 @@ async def run_imputation_sweep(
                 random_state=kwargs["random_state"],
             )
             progress_callback("imputing", 0.1)
-            try:
-                imputed = phil_obj.fit(prepared_df, max_iter=kwargs["max_iter"])
-            except Exception as exc:  # pragma: no cover - defensive
-                raise exc
+            imputed = phil_obj.fit(prepared_df, max_iter=kwargs["max_iter"])
             progress_callback("scoring", 0.85)
             descriptors = list(phil_obj.magic_descriptors)
             progress_callback("done", 1.0)
@@ -1209,7 +1208,7 @@ async def run_imputation_sweep(
                 "max_iter": kwargs["max_iter"],
                 "random_state": kwargs["random_state"],
                 "method_counts": method_counts,
-                "n_rows": int(len(prepared_df)),
+                "n_rows": len(prepared_df),
                 "n_cols": int(prepared_df.shape[1]),
                 "total_missing": total_missing,
                 "dropped_columns": dropped_columns,
@@ -1259,7 +1258,7 @@ async def run_imputation_sweep(
             agent_action=e.agent_action,
             details=e.details,
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("run_imputation_sweep", str(e))
 
 
@@ -1320,7 +1319,7 @@ async def diagnose_sweep(run_id: str = "", ctx: Context = None) -> str:
             "config_yaml": record.config_yaml,
         }
         return json.dumps(payload, indent=2)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("diagnose_sweep", str(e))
 
 
@@ -1377,7 +1376,7 @@ async def get_candidate_descriptors(
             },
             indent=2,
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("get_candidate_descriptors", str(e))
 
 
@@ -1411,7 +1410,7 @@ async def compare_sweeps(run_a: str, run_b: str, ctx: Context = None) -> str:
             },
         }
         return json.dumps(payload, indent=2)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("compare_sweeps", str(e))
 
 
@@ -1468,7 +1467,7 @@ async def get_sweep_summary(run_id: str = "", ctx: Context = None) -> str:
         if record is None:
             return unknown_handle_error("get_sweep_summary", "run_id", run_id)
         return json.dumps(dataclasses.asdict(record), indent=2)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("get_sweep_summary", str(e))
 
 
@@ -1503,9 +1502,9 @@ async def export_imputed_data(
         target = _normalize_data_path(output_path)
         Path(target).parent.mkdir(parents=True, exist_ok=True)
         lowered = target.lower()
-        if lowered.endswith(".parquet") or lowered.endswith(".pq"):
+        if lowered.endswith((".parquet", ".pq")):
             await asyncio.to_thread(_write_parquet, session.imputed, target)
-        elif lowered.endswith(".feather") or lowered.endswith(".arrow"):
+        elif lowered.endswith((".feather", ".arrow")):
             await asyncio.to_thread(_write_feather, session.imputed, target)
         else:
             await asyncio.to_thread(_write_csv, session.imputed, target)
@@ -1514,12 +1513,12 @@ async def export_imputed_data(
                 "status": "ok",
                 "run_id": session.latest_run_id,
                 "output_path": target,
-                "n_rows": int(len(session.imputed)),
+                "n_rows": len(session.imputed),
                 "n_cols": int(session.imputed.shape[1]),
             },
             indent=2,
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return mcp_error("export_imputed_data", str(e))
 
 

--- a/phil/mcp/server.py
+++ b/phil/mcp/server.py
@@ -769,7 +769,8 @@ def _decode_categorical_columns(
 async def list_grids(ctx: Context = None) -> str:
     """
     Return the built-in imputation grids registered with Phil's
-    ``GridGallery``, including the method list and intent blurb.
+    ``GridGallery``, including method lists and declarative metadata
+    (intent, suitability, affinity, time complexity, scale limits).
     """
     try:
         payload = {

--- a/phil/mcp/server.py
+++ b/phil/mcp/server.py
@@ -828,8 +828,6 @@ async def recommend_grid(
         return unknown_handle_error("recommend_grid", "dataset_id", dataset_id)
     except FileNotFoundError:
         return path_access_error("recommend_grid", data_path or dataset_id)
-    except ToolError as e:
-        return mcp_error("recommend_grid", str(e))
     except Exception as e:
         return mcp_error("recommend_grid", str(e))
 

--- a/phil/phil.py
+++ b/phil/phil.py
@@ -135,6 +135,26 @@ class Phil:
         imported_module = importlib.import_module(module)
         return getattr(imported_module, method)
 
+    def _map_covariate_subsets(self, domain_knowledge) -> dict:
+        mapped_subsets = {}
+        for target, subset_config in domain_knowledge.covariate_subsets.items():
+            target_mapped = (
+                f"num__{target}"
+                if f"num__{target}" in self.feature_names_out_
+                else f"cat__{target}"
+            )
+            preds_mapped = []
+            for p in subset_config.predictors:
+                if f"num__{p}" in self.feature_names_out_:
+                    preds_mapped.append(f"num__{p}")
+                elif f"cat__{p}" in self.feature_names_out_:
+                    preds_mapped.append(f"cat__{p}")
+                else:
+                    preds_mapped.append(p)
+
+            mapped_subsets[target_mapped] = {"predictors": preds_mapped}
+        return mapped_subsets
+
     def _build_pipeline(
         self,
         preprocessor: ColumnTransformer,
@@ -148,12 +168,26 @@ class Phil:
         # directly instead of wrapping again inside IterativeImputer.
         if method in _STANDALONE_IMPUTERS:
             imputer = estimator
-            if hasattr(imputer, "set_params"):
-                # Prefer Phil's random_state when the imputer supports it.
-                try:
-                    imputer.set_params(random_state=self.random_state)
-                except ValueError:
-                    pass
+            if hasattr(imputer, "get_params") and hasattr(imputer, "set_params"):
+                params = imputer.get_params()
+                updates = {}
+                if "random_state" in params:
+                    updates["random_state"] = self.random_state
+                if "max_iter" in params:
+                    updates["max_iter"] = max_iter
+                if (
+                    method == "MaskedIterativeImputer"
+                    and domain_knowledge
+                    and domain_knowledge.covariate_subsets
+                    and "covariate_subsets" in params
+                ):
+                    updates["covariate_subsets"] = self._map_covariate_subsets(
+                        domain_knowledge
+                    )
+                    if "feature_names" in params:
+                        updates["feature_names"] = self.feature_names_out_
+                if updates:
+                    imputer.set_params(**updates)
             return Pipeline(
                 [
                     ("preprocessor", preprocessor),
@@ -162,23 +196,7 @@ class Phil:
             )
 
         if domain_knowledge and domain_knowledge.covariate_subsets:
-            mapped_subsets = {}
-            for target, subset_config in domain_knowledge.covariate_subsets.items():
-                target_mapped = (
-                    f"num__{target}"
-                    if f"num__{target}" in self.feature_names_out_
-                    else f"cat__{target}"
-                )
-                preds_mapped = []
-                for p in subset_config.predictors:
-                    if f"num__{p}" in self.feature_names_out_:
-                        preds_mapped.append(f"num__{p}")
-                    elif f"cat__{p}" in self.feature_names_out_:
-                        preds_mapped.append(f"cat__{p}")
-                    else:
-                        preds_mapped.append(p)
-
-                mapped_subsets[target_mapped] = {"predictors": preds_mapped}
+            mapped_subsets = self._map_covariate_subsets(domain_knowledge)
 
             imputer = MaskedIterativeImputer(
                 estimator=estimator,

--- a/phil/phil.py
+++ b/phil/phil.py
@@ -16,6 +16,24 @@ from phil.imputation import ImputationConfig, MaskedIterativeImputer
 from phil.magic import Magic
 import phil.magic as METHODS
 
+# Methods that are already imputers — do not wrap again in IterativeImputer.
+_STANDALONE_IMPUTERS = {
+    "SimpleImputer",
+    "KNNImputer",
+    "IterativeImputer",
+    "MaskedIterativeImputer",
+}
+
+# String estimator names used in gallery ParameterGrids for IterativeImputer.
+_NAMED_ESTIMATORS = {
+    "BayesianRidge": ("sklearn.linear_model", "BayesianRidge"),
+    "RandomForestRegressor": ("sklearn.ensemble", "RandomForestRegressor"),
+    "ExtraTreesRegressor": ("sklearn.ensemble", "ExtraTreesRegressor"),
+    "GradientBoostingRegressor": ("sklearn.ensemble", "GradientBoostingRegressor"),
+    "DecisionTreeRegressor": ("sklearn.tree", "DecisionTreeRegressor"),
+    "KNeighborsRegressor": ("sklearn.neighbors", "KNeighborsRegressor"),
+}
+
 
 class Phil:
     def __init__(
@@ -77,6 +95,7 @@ class Phil:
                     for k, v in param_vals.items()
                     if k in model.__init__.__code__.co_varnames
                 }
+                compatible_params = self._resolve_estimator_params(compatible_params)
 
                 if (
                     domain_knowledge
@@ -90,10 +109,26 @@ class Phil:
                 estimator = model(**compatible_params)
                 imputers.append(
                     self._build_pipeline(
-                        preprocessor, estimator, max_iter, domain_knowledge
+                        preprocessor,
+                        estimator,
+                        max_iter,
+                        domain_knowledge,
+                        method=method,
                     )
                 )
         return imputers
+
+    @classmethod
+    def _resolve_estimator_params(cls, params: dict) -> dict:
+        """Materialize string estimator names used by gallery grids."""
+        resolved = dict(params)
+        est = resolved.get("estimator")
+        if isinstance(est, str):
+            if est not in _NAMED_ESTIMATORS:
+                raise ValueError(f"Unknown estimator name in grid: {est!r}")
+            module_name, class_name = _NAMED_ESTIMATORS[est]
+            resolved["estimator"] = cls._import_model(module_name, class_name)()
+        return resolved
 
     @staticmethod
     def _import_model(module: str, method: str):
@@ -106,7 +141,25 @@ class Phil:
         estimator,
         max_iter: int,
         domain_knowledge=None,
+        method: str | None = None,
     ) -> Pipeline:
+
+        # Gallery domain grids list sklearn imputers as methods. Use them
+        # directly instead of wrapping again inside IterativeImputer.
+        if method in _STANDALONE_IMPUTERS:
+            imputer = estimator
+            if hasattr(imputer, "set_params"):
+                # Prefer Phil's random_state when the imputer supports it.
+                try:
+                    imputer.set_params(random_state=self.random_state)
+                except ValueError:
+                    pass
+            return Pipeline(
+                [
+                    ("preprocessor", preprocessor),
+                    ("imputer", imputer),
+                ]
+            )
 
         if domain_knowledge and domain_knowledge.covariate_subsets:
             mapped_subsets = {}

--- a/phil/phil.py
+++ b/phil/phil.py
@@ -1,6 +1,6 @@
 import importlib
 import warnings
-from typing import Any, List, Tuple
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -11,10 +11,10 @@ from sklearn.experimental import enable_iterative_imputer  # noqa: F401
 from sklearn.impute import IterativeImputer
 from sklearn.pipeline import Pipeline
 
+import phil.magic as METHODS
 from phil.gallery import GridGallery, MagicGallery, ProcessingGallery
 from phil.imputation import ImputationConfig, MaskedIterativeImputer
 from phil.magic import Magic
-import phil.magic as METHODS
 
 # Methods that are already imputers — do not wrap again in IterativeImputer.
 _STANDALONE_IMPUTERS = {
@@ -53,7 +53,7 @@ class Phil:
         self.representations = []
         self.magic_descriptors = []
 
-    def impute(self, df: pd.DataFrame, max_iter: int = 10) -> List[np.ndarray]:
+    def impute(self, df: pd.DataFrame, max_iter: int = 10) -> list[np.ndarray]:
         if df.isnull().sum().sum() == 0:
             raise ValueError("No missing values found in the input DataFrame.")
         categorical_columns, numerical_columns = self._identify_column_types(df)
@@ -68,7 +68,7 @@ class Phil:
         return self._apply_imputations(df, self.selected_imputers)
 
     @staticmethod
-    def _identify_column_types(df: pd.DataFrame) -> Tuple[List[str], List[str]]:
+    def _identify_column_types(df: pd.DataFrame) -> tuple[list[str], list[str]]:
         categorical_columns = df.select_dtypes(
             include=["object", "category", "str"]
         ).columns.tolist()
@@ -79,7 +79,7 @@ class Phil:
 
     def _create_imputers(
         self, preprocessor: ColumnTransformer, max_iter: int
-    ) -> List[Pipeline]:
+    ) -> list[Pipeline]:
         imputers = []
         domain_knowledge = getattr(self.param_grid, "domain_knowledge", None)
 
@@ -219,7 +219,7 @@ class Phil:
             ]
         )
 
-    def _select_imputations(self, imputers: List[Pipeline]) -> List[Pipeline]:
+    def _select_imputations(self, imputers: list[Pipeline]) -> list[Pipeline]:
         np.random.seed(self.random_state)
         selected_idxs = np.random.choice(
             range(len(imputers)),
@@ -229,8 +229,8 @@ class Phil:
         return [imputers[idx] for idx in selected_idxs]
 
     def _apply_imputations(
-        self, df: pd.DataFrame, imputers: List[Pipeline]
-    ) -> List[np.ndarray]:
+        self, df: pd.DataFrame, imputers: list[Pipeline]
+    ) -> list[np.ndarray]:
         imputations = []
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=ConvergenceWarning)
@@ -239,7 +239,7 @@ class Phil:
                 imputations.append(imputer.transform(df))
             return imputations
 
-    def generate_descriptors(self) -> List[np.ndarray]:
+    def generate_descriptors(self) -> list[np.ndarray]:
         return self.magic.generate(self.representations)
 
     def fit(self, df: pd.DataFrame, max_iter: int = 5) -> pd.DataFrame:
@@ -265,11 +265,11 @@ class Phil:
         return pd.DataFrame(self.pipeline.transform(df), columns=imputed_columns)
 
     @staticmethod
-    def _get_imputed_columns(transformer: ColumnTransformer) -> List[str]:
+    def _get_imputed_columns(transformer: ColumnTransformer) -> list[str]:
         return transformer.get_feature_names_out()
 
     @staticmethod
-    def _select_representative(descriptors: List[np.ndarray]) -> int:
+    def _select_representative(descriptors: list[np.ndarray]) -> int:
         stacked = np.stack(descriptors)
         avg_descriptor = stacked.mean(axis=0)
         norms = np.linalg.norm(
@@ -278,7 +278,7 @@ class Phil:
         return int(np.argmin(norms))
 
     @staticmethod
-    def _configure_magic_method(magic: str, config) -> Tuple[BaseModel, Magic]:
+    def _configure_magic_method(magic: str, config) -> tuple[BaseModel, Magic]:
         magic_method = getattr(METHODS, magic, None)
         if magic_method is None:
             raise ValueError(f"Magic method '{magic}' not found.")
@@ -325,11 +325,11 @@ class Phil:
     @staticmethod
     def _configure_preprocessor(
         strategy: str,
-        categorical_columns: List[str],
-        numerical_columns: List[str],
+        categorical_columns: list[str],
+        numerical_columns: list[str],
     ) -> ColumnTransformer:
         strategy = ProcessingGallery.get(strategy)
-        transformers: List[Tuple[str, Any, List[str]]] = []
+        transformers: list[tuple[str, Any, list[str]]] = []
 
         for key, preprocessing_config in strategy.items():
             try:

--- a/phil/transformers.py
+++ b/phil/transformers.py
@@ -2,7 +2,7 @@
 Scikit-learn compatible transformers for Phil.
 """
 
-from typing import Any, Optional, Union
+from typing import Any
 
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -15,10 +15,10 @@ class PhilTransformer(BaseEstimator, TransformerMixin):
     def __init__(
         self,
         samples: int = 30,
-        param_grid: Union[str, ImputationConfig] = "default",
+        param_grid: str | ImputationConfig = "default",
         magic: str = "ECT",
-        config: Optional[dict] = None,
-        random_state: Optional[int] = None,
+        config: dict | None = None,
+        random_state: int | None = None,
         max_iter: int = 5,
     ):
         self.samples = samples

--- a/phil/visualization.py
+++ b/phil/visualization.py
@@ -20,13 +20,13 @@ def plot_mds(
     ax=None,
     figsize: tuple[int, int] = (8, 6),
     random_state: int | None = None,
-) -> tuple["Figure", np.ndarray]:
+) -> tuple[Figure, np.ndarray]:
     """
     Visualize the ECT descriptor space via Multi-Dimensional Scaling (MDS).
     """
     try:
-        import matplotlib.pyplot as plt
         import matplotlib.patheffects as pe
+        import matplotlib.pyplot as plt
     except ImportError as exc:
         raise ImportError(
             "matplotlib is required for visualization. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "pytest-cov>=6.1.1",
     "pytest-mock>=3.14.0",
-    "ruff>=0.15.8",
+    "ruff>=0.16.0",
 ]
 mcp = [
     "fastmcp>=2.0",

--- a/tests/magic/test_ect.py
+++ b/tests/magic/test_ect.py
@@ -160,7 +160,7 @@ class TestECT:
         X = np.random.rand(10, 2)  # Single numpy array, not in a list
 
         # Act & Assert
-        with pytest.raises(ValueError, match="Input must be a list of numpy arrays"):
+        with pytest.raises(TypeError, match="Input must be a list of numpy arrays"):
             ect.generate(X)
 
     def test_normalization(self):

--- a/tests/mcp/test_config.py
+++ b/tests/mcp/test_config.py
@@ -144,3 +144,16 @@ def test_list_builtin_grids_includes_default() -> None:
     assert "healthcare" in names
     default_entry = next(g for g in grids if g["name"] == "default")
     assert default_entry["methods"]
+    assert default_entry["target_domain"] == "general"
+    assert default_entry["time_complexity"] in {"Low", "Medium", "High"}
+    assert default_entry["suitability"]
+    assert default_entry["data_type_affinity"]
+    assert default_entry["scale_limits"]
+
+
+def test_list_builtin_grids_healthcare_metadata() -> None:
+    grids = list_builtin_grids()
+    healthcare = next(g for g in grids if g["name"] == "healthcare")
+    assert healthcare["time_complexity"] == "High"
+    assert "KNN" in healthcare["scale_limits"] or "100" in healthcare["scale_limits"]
+

--- a/tests/mcp/test_config.py
+++ b/tests/mcp/test_config.py
@@ -156,4 +156,3 @@ def test_list_builtin_grids_healthcare_metadata() -> None:
     healthcare = next(g for g in grids if g["name"] == "healthcare")
     assert healthcare["time_complexity"] == "High"
     assert "KNN" in healthcare["scale_limits"] or "100" in healthcare["scale_limits"]
-

--- a/tests/mcp/test_config.py
+++ b/tests/mcp/test_config.py
@@ -40,6 +40,15 @@ def test_fenced_markdown_yaml_rejected() -> None:
     assert report.error_code == "YAML_NOT_RAW"
 
 
+def test_non_mapping_yaml_rejected() -> None:
+    report = validate_config_yaml("123")
+    assert not report.ok
+    assert report.error_code == "CONFIG_YAML_INVALID"
+    assert any("mapping" in issue.message.lower() for issue in report.issues)
+    assert report.agent_action is not None
+    assert "mapping" in report.agent_action.lower()
+
+
 def test_unknown_grid_rejected() -> None:
     config_yaml = "imputation:\n  grid: bogus\n"
     report = validate_config_yaml(config_yaml)

--- a/tests/mcp/test_recommend.py
+++ b/tests/mcp/test_recommend.py
@@ -27,7 +27,10 @@ def test_recommend_default_for_small_mixed_frame() -> None:
     result = recommend_grid_for_dataframe(df)
     assert result["status"] == "ok"
     assert result["recommended_grid"] == "default"
-    assert result["suggested_samples"] == 20
+    # 2/8 cells missing → FMI proxy 0.25 → m≈25, no KNN cap 30
+    assert result["suggested_samples"] == 25
+    assert result["scalability"]["grid_candidate_count"] == 17
+    assert result["sample_budget"]["m_efficiency_floor"] == 5
     assert "Recommended Grid: default" in result["recommendation"]
     assert result["grid"]["name"] == "default"
     assert result["metrics"]["n_rows"] == 4
@@ -41,11 +44,13 @@ def test_recommend_sampling_for_large_continuous_frame() -> None:
             "y": rng.normal(size=100_001),
         }
     )
-    # Introduce a bit of missingness without changing scale heuristics.
     df.loc[:10, "x"] = np.nan
     result = recommend_grid_for_dataframe(df)
     assert result["recommended_grid"] == "sampling"
-    assert result["suggested_samples"] == 10
+    # Tiny missingness + large N → efficiency floor, scalability/sampling cap
+    assert result["suggested_samples"] == 5
+    assert result["scalability"]["has_knn"] is False
+    assert result["subsample"] is not None
     assert any("100,000" in w or "KNN" in w for w in result["warnings"])
 
 
@@ -60,8 +65,9 @@ def test_recommend_default_for_large_categorical_frame() -> None:
     )
     result = recommend_grid_for_dataframe(df)
     assert result["recommended_grid"] == "default"
-    assert result["suggested_samples"] == 10
+    assert result["suggested_samples"] == 5
     assert result["warnings"]
+    assert result["scalable_alternatives"]
 
 
 def test_recommend_marketing_for_high_cardinality() -> None:
@@ -74,8 +80,11 @@ def test_recommend_marketing_for_high_cardinality() -> None:
     df.loc[0, "spend"] = np.nan
     result = recommend_grid_for_dataframe(df)
     assert result["recommended_grid"] == "marketing"
-    assert result["suggested_samples"] == 15
+    # ~0.8% missing → m≈5; marketing has KNN so cap 15 → 5
+    assert result["suggested_samples"] == 5
+    assert result["scalability"]["has_knn"] is True
     assert "zip" in result["metrics"]["high_cardinality_columns"]
+    assert any(a["grid"] == "default" for a in result["scalable_alternatives"])
 
 
 def test_recommend_warns_on_extreme_missingness() -> None:
@@ -88,7 +97,10 @@ def test_recommend_warns_on_extreme_missingness() -> None:
     result = recommend_grid_for_dataframe(df)
     assert result["recommended_grid"] == "default"
     assert result["metrics"]["overall_missing_pct"] > 50
+    # 75% missing → m_stability 40, no-KNN cap 30 → 30
+    assert result["suggested_samples"] == 30
     assert any("50%" in w for w in result["warnings"])
+
 
 def test_recommend_marketing_for_integer_high_cardinality_ids() -> None:
     """ZIP-style integer IDs should still trigger the marketing grid."""
@@ -102,4 +114,32 @@ def test_recommend_marketing_for_integer_high_cardinality_ids() -> None:
     result = recommend_grid_for_dataframe(df)
     assert result["recommended_grid"] == "marketing"
     assert "zip_code" in result["metrics"]["high_cardinality_columns"]
+    assert result["sample_budget"]["literature_notes"]
 
+def test_recommend_marketing_for_nullable_integer_ids() -> None:
+    """Nullable Int64 IDs with NA still count as high-cardinality categoricals."""
+    df = pd.DataFrame(
+        {
+            "zip_code": pd.array(list(range(10000, 10080)) + [pd.NA], dtype="Int64"),
+            "spend": list(range(81)),
+        }
+    )
+    df.loc[1, "spend"] = np.nan
+    result = recommend_grid_for_dataframe(df)
+    assert result["recommended_grid"] == "marketing"
+    assert "zip_code" in result["metrics"]["high_cardinality_columns"]
+
+
+def test_recommend_default_for_integral_float_lab_values() -> None:
+    """Whole-number lab floats (glucose/insulin-like) are not marketing IDs."""
+    df = pd.DataFrame(
+        {
+            "glucose": [float(i) for i in range(80, 200)],
+            "bmi": list(range(120)),
+        }
+    )
+    df.loc[0, "glucose"] = np.nan
+    df.loc[1, "bmi"] = np.nan
+    result = recommend_grid_for_dataframe(df)
+    assert result["recommended_grid"] == "default"
+    assert "glucose" not in result["metrics"]["high_cardinality_columns"]

--- a/tests/mcp/test_recommend.py
+++ b/tests/mcp/test_recommend.py
@@ -1,0 +1,91 @@
+"""Unit tests for declarative grid metadata and the rule-based recommender."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from phil.gallery import GRID_METADATA, render_imputation_matrix
+from phil.mcp.recommend import recommend_grid_for_dataframe
+
+
+def test_render_imputation_matrix_includes_all_grids() -> None:
+    md = render_imputation_matrix()
+    assert md.startswith("# Phil Imputation Grid Matrix")
+    assert "| Grid | Domain | Complexity |" in md
+    for name in GRID_METADATA:
+        assert f"`{name}`" in md
+
+
+def test_recommend_default_for_small_mixed_frame() -> None:
+    df = pd.DataFrame(
+        {
+            "a": [1.0, np.nan, 3.0, 4.0],
+            "b": ["x", "y", None, "x"],
+        }
+    )
+    result = recommend_grid_for_dataframe(df)
+    assert result["status"] == "ok"
+    assert result["recommended_grid"] == "default"
+    assert result["suggested_samples"] == 20
+    assert "Recommended Grid: default" in result["recommendation"]
+    assert result["grid"]["name"] == "default"
+    assert result["metrics"]["n_rows"] == 4
+
+
+def test_recommend_sampling_for_large_continuous_frame() -> None:
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "x": rng.normal(size=100_001),
+            "y": rng.normal(size=100_001),
+        }
+    )
+    # Introduce a bit of missingness without changing scale heuristics.
+    df.loc[:10, "x"] = np.nan
+    result = recommend_grid_for_dataframe(df)
+    assert result["recommended_grid"] == "sampling"
+    assert result["suggested_samples"] == 10
+    assert any("100,000" in w or "KNN" in w for w in result["warnings"])
+
+
+def test_recommend_default_for_large_categorical_frame() -> None:
+    rng = np.random.default_rng(1)
+    n = 100_001
+    df = pd.DataFrame(
+        {
+            "x": rng.normal(size=n),
+            "cat": rng.choice(["a", "b", "c"], size=n),
+        }
+    )
+    result = recommend_grid_for_dataframe(df)
+    assert result["recommended_grid"] == "default"
+    assert result["suggested_samples"] == 10
+    assert result["warnings"]
+
+
+def test_recommend_marketing_for_high_cardinality() -> None:
+    df = pd.DataFrame(
+        {
+            "zip": [f"z{i}" for i in range(60)],
+            "spend": list(range(60)),
+        }
+    )
+    df.loc[0, "spend"] = np.nan
+    result = recommend_grid_for_dataframe(df)
+    assert result["recommended_grid"] == "marketing"
+    assert result["suggested_samples"] == 15
+    assert "zip" in result["metrics"]["high_cardinality_columns"]
+
+
+def test_recommend_warns_on_extreme_missingness() -> None:
+    df = pd.DataFrame(
+        {
+            "a": [1.0, np.nan, np.nan, np.nan],
+            "b": [np.nan, np.nan, np.nan, 2.0],
+        }
+    )
+    result = recommend_grid_for_dataframe(df)
+    assert result["recommended_grid"] == "default"
+    assert result["metrics"]["overall_missing_pct"] > 50
+    assert any("50%" in w for w in result["warnings"])

--- a/tests/mcp/test_recommend.py
+++ b/tests/mcp/test_recommend.py
@@ -5,16 +5,32 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from phil.gallery import GRID_METADATA, render_imputation_matrix
+from phil.gallery import (
+    GRID_METADATA,
+    GridGallery,
+    grid_candidate_count,
+    render_imputation_matrix,
+)
 from phil.mcp.recommend import recommend_grid_for_dataframe
+
+
+def test_grid_metadata_parity_with_gallery() -> None:
+    # Agent-facing metadata must not reference missing gallery keys
+    # (GridGallery.get silently falls back to default).
+    assert set(GRID_METADATA).issubset(set(GridGallery._grids))
 
 
 def test_render_imputation_matrix_includes_all_grids() -> None:
     md = render_imputation_matrix()
     assert md.startswith("# Phil Imputation Grid Matrix")
     assert "| Grid | Domain | Complexity |" in md
+    assert "## Estimator / complexity notes" in md
+    assert "cost_tier" not in md  # header uses human label
+    assert "| Cost tier |" in md
     for name in GRID_METADATA:
         assert f"`{name}`" in md
+        # Live scalability rows include each grid method list.
+        assert grid_candidate_count(name) >= 1
 
 
 def test_recommend_default_for_small_mixed_frame() -> None:
@@ -29,7 +45,9 @@ def test_recommend_default_for_small_mixed_frame() -> None:
     assert result["recommended_grid"] == "default"
     # 2/8 cells missing → FMI proxy 0.25 → m≈25, no KNN cap 30
     assert result["suggested_samples"] == 25
-    assert result["scalability"]["grid_candidate_count"] == 17
+    assert result["scalability"]["grid_candidate_count"] == grid_candidate_count(
+        "default"
+    )
     assert result["sample_budget"]["m_efficiency_floor"] == 5
     assert "Recommended Grid: default" in result["recommendation"]
     assert result["grid"]["name"] == "default"
@@ -85,6 +103,7 @@ def test_recommend_marketing_for_high_cardinality() -> None:
     assert result["scalability"]["has_knn"] is True
     assert "zip" in result["metrics"]["high_cardinality_columns"]
     assert any(a["grid"] == "default" for a in result["scalable_alternatives"])
+    assert "TargetEncoder" not in " ".join(result["rationale"])
 
 
 def test_recommend_warns_on_extreme_missingness() -> None:
@@ -97,8 +116,9 @@ def test_recommend_warns_on_extreme_missingness() -> None:
     result = recommend_grid_for_dataframe(df)
     assert result["recommended_grid"] == "default"
     assert result["metrics"]["overall_missing_pct"] > 50
-    # 75% missing → m_stability 40, no-KNN cap 30 → 30
+    # 75% missing → m_from_missing 75, stability cap 30 → 30
     assert result["suggested_samples"] == 30
+    assert result["sample_budget"]["m_stability_uncapped"] == 75
     assert any("50%" in w for w in result["warnings"])
 
 
@@ -115,6 +135,9 @@ def test_recommend_marketing_for_integer_high_cardinality_ids() -> None:
     assert result["recommended_grid"] == "marketing"
     assert "zip_code" in result["metrics"]["high_cardinality_columns"]
     assert result["sample_budget"]["literature_notes"]
+    assert not any(
+        "Rubin" in note for note in result["sample_budget"]["literature_notes"]
+    )
 
 
 def test_recommend_marketing_for_nullable_integer_ids() -> None:
@@ -144,3 +167,47 @@ def test_recommend_default_for_integral_float_lab_values() -> None:
     result = recommend_grid_for_dataframe(df)
     assert result["recommended_grid"] == "default"
     assert "glucose" not in result["metrics"]["high_cardinality_columns"]
+
+
+def test_recommend_default_for_integer_measurements_without_nas() -> None:
+    """Ordinary integer measurements must not route to marketing."""
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "age": np.arange(200) % 80,
+            "salary": np.arange(200) * 100,
+            "x": rng.normal(size=200),
+        }
+    )
+    df.loc[0, "x"] = np.nan
+    result = recommend_grid_for_dataframe(df)
+    assert result["recommended_grid"] == "default"
+    assert "age" not in result["metrics"]["high_cardinality_columns"]
+    assert "salary" not in result["metrics"]["high_cardinality_columns"]
+
+
+def test_recommend_warns_when_high_cardinality_and_extreme_missing() -> None:
+    df = pd.DataFrame(
+        {
+            "zip": [f"z{i}" for i in range(60)],
+            "sparse": [np.nan] * 55 + [1.0] * 5,
+        }
+    )
+    result = recommend_grid_for_dataframe(df)
+    assert result["recommended_grid"] == "marketing"
+    assert any("50%" in w for w in result["warnings"])
+    assert result["metrics"]["max_col_missing_pct"] > 50
+
+
+def test_recommend_single_column_and_empty_frames() -> None:
+    empty = recommend_grid_for_dataframe(pd.DataFrame())
+    assert empty["recommended_grid"] == "default"
+    assert empty["metrics"]["n_rows"] == 0
+
+    single = recommend_grid_for_dataframe(pd.DataFrame({"a": [1.0, np.nan, 3.0, 4.0]}))
+    assert single["recommended_grid"] == "default"
+    assert single["metrics"]["n_cols"] == 1
+
+
+def test_marketing_candidate_count() -> None:
+    assert grid_candidate_count("marketing") == 8

--- a/tests/mcp/test_recommend.py
+++ b/tests/mcp/test_recommend.py
@@ -89,3 +89,17 @@ def test_recommend_warns_on_extreme_missingness() -> None:
     assert result["recommended_grid"] == "default"
     assert result["metrics"]["overall_missing_pct"] > 50
     assert any("50%" in w for w in result["warnings"])
+
+def test_recommend_marketing_for_integer_high_cardinality_ids() -> None:
+    """ZIP-style integer IDs should still trigger the marketing grid."""
+    df = pd.DataFrame(
+        {
+            "zip_code": list(range(10000, 10080)),
+            "spend": list(range(80)),
+        }
+    )
+    df.loc[0, "spend"] = np.nan
+    result = recommend_grid_for_dataframe(df)
+    assert result["recommended_grid"] == "marketing"
+    assert "zip_code" in result["metrics"]["high_cardinality_columns"]
+

--- a/tests/mcp/test_recommend.py
+++ b/tests/mcp/test_recommend.py
@@ -116,6 +116,7 @@ def test_recommend_marketing_for_integer_high_cardinality_ids() -> None:
     assert "zip_code" in result["metrics"]["high_cardinality_columns"]
     assert result["sample_budget"]["literature_notes"]
 
+
 def test_recommend_marketing_for_nullable_integer_ids() -> None:
     """Nullable Int64 IDs with NA still count as high-cardinality categoricals."""
     df = pd.DataFrame(

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -121,11 +121,10 @@ async def test_imputation_matrix_resource() -> None:
         uris = {str(r.uri) for r in resources}
         assert "phil://docs/imputation-matrix" in uris
         contents = await client.read_resource("phil://docs/imputation-matrix")
-        text = "".join(
-            getattr(part, "text", "") or "" for part in contents
-        )
+        text = "".join(getattr(part, "text", "") or "" for part in contents)
         assert "Phil Imputation Grid Matrix" in text
         assert "`healthcare`" in text
+
 
 @pytest.mark.asyncio
 async def test_end_to_end_csv_sweep(
@@ -348,4 +347,3 @@ imputation:
         )
         assert run["status"] == "error"
         assert run["error_code"] == "UNSUPPORTED_STRING_COLUMNS"
-

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -115,6 +115,33 @@ async def test_recommend_grid_after_ingest(csv_path: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_recommend_grid_unknown_dataset_id() -> None:
+    async with Client(mcp) as client:
+        result = _payload(
+            await client.call_tool(
+                "recommend_grid", {"dataset_id": "ds_does_not_exist"}
+            )
+        )
+        assert result.get("status") == "error" or "error" in result
+        blob = json.dumps(result)
+        assert "DATASET_ID_UNKNOWN" in blob or "Unknown dataset_id" in blob
+
+
+@pytest.mark.asyncio
+async def test_recommend_grid_bad_data_path() -> None:
+    async with Client(mcp) as client:
+        result = _payload(
+            await client.call_tool(
+                "recommend_grid",
+                {"data_path": "/tmp/phil_definitely_missing_12345.csv"},
+            )
+        )
+        assert result.get("status") == "error" or "error" in result
+        blob = json.dumps(result)
+        assert "FILE_NOT_FOUND" in blob or "not exist" in blob.lower()
+
+
+@pytest.mark.asyncio
 async def test_imputation_matrix_resource() -> None:
     async with Client(mcp) as client:
         resources = await client.list_resources()

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -86,6 +86,10 @@ async def test_list_grids_returns_builtins() -> None:
         names = {g["name"] for g in payload["grids"]}
         assert "default" in names
         assert "healthcare" in names
+        healthcare = next(g for g in payload["grids"] if g["name"] == "healthcare")
+        assert healthcare["time_complexity"] == "High"
+        assert healthcare["suitability"]
+        assert "scale_limits" in healthcare
 
 
 @pytest.mark.asyncio
@@ -309,3 +313,4 @@ imputation:
         )
         assert run["status"] == "error"
         assert run["error_code"] == "UNSUPPORTED_STRING_COLUMNS"
+

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -93,6 +93,41 @@ async def test_list_grids_returns_builtins() -> None:
 
 
 @pytest.mark.asyncio
+async def test_recommend_grid_after_ingest(csv_path: str) -> None:
+    async with Client(mcp) as client:
+        ingest = _payload(await client.call_tool("ingest_dataset", {"path": csv_path}))
+        dataset_id = ingest["dataset_id"]
+        result = _payload(
+            await client.call_tool("recommend_grid", {"dataset_id": dataset_id})
+        )
+        assert result["status"] == "ok"
+        assert result["recommended_grid"] in {
+            "default",
+            "sampling",
+            "finance",
+            "healthcare",
+            "marketing",
+            "engineering",
+        }
+        assert "suggested_samples" in result
+        assert "Recommended Grid:" in result["recommendation"]
+        assert result["grid"]["name"] == result["recommended_grid"]
+
+
+@pytest.mark.asyncio
+async def test_imputation_matrix_resource() -> None:
+    async with Client(mcp) as client:
+        resources = await client.list_resources()
+        uris = {str(r.uri) for r in resources}
+        assert "phil://docs/imputation-matrix" in uris
+        contents = await client.read_resource("phil://docs/imputation-matrix")
+        text = "".join(
+            getattr(part, "text", "") or "" for part in contents
+        )
+        assert "Phil Imputation Grid Matrix" in text
+        assert "`healthcare`" in text
+
+@pytest.mark.asyncio
 async def test_end_to_end_csv_sweep(
     csv_path: str, tmp_path: Path, patched_phil
 ) -> None:

--- a/tests/phil/test_grid_pipelines.py
+++ b/tests/phil/test_grid_pipelines.py
@@ -1,0 +1,59 @@
+"""Pipeline construction tests for built-in gallery grids."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.impute import IterativeImputer
+
+from phil.gallery import GRID_METADATA, GridGallery, grid_candidate_count
+from phil.phil import Phil
+
+
+def _tiny_missing_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "x": [1.0, np.nan, 3.0, 4.0, 5.0],
+            "y": [2.0, 3.0, np.nan, 5.0, 6.0],
+        }
+    )
+
+
+@pytest.mark.parametrize("grid_name", sorted(GRID_METADATA))
+def test_builtin_grid_constructs_and_imputes(grid_name: str) -> None:
+    phil = Phil(param_grid=grid_name, samples=2, random_state=0)
+    result = phil.impute(_tiny_missing_frame(), max_iter=2)
+    assert len(result) == 2
+    assert all(isinstance(arr, np.ndarray) for arr in result)
+
+
+def test_caller_max_iter_applied_to_standalone_iterative() -> None:
+    phil = Phil(param_grid="marketing", samples=3, random_state=0)
+    # Build pipelines without sampling so we can inspect max_iter.
+    categorical_columns, numerical_columns = phil._identify_column_types(
+        _tiny_missing_frame()
+    )
+    preprocessor = phil._configure_preprocessor(
+        "default", categorical_columns, numerical_columns
+    )
+    preprocessor.fit(_tiny_missing_frame())
+    phil.feature_names_out_ = preprocessor.get_feature_names_out().tolist()
+    pipelines = phil._create_imputers(preprocessor, max_iter=17)
+
+    iterative = [
+        pipe.named_steps["imputer"]
+        for pipe in pipelines
+        if isinstance(pipe.named_steps["imputer"], IterativeImputer)
+    ]
+    assert iterative
+    assert all(imp.get_params()["max_iter"] == 17 for imp in iterative)
+
+
+def test_grid_metadata_matches_gallery_keys() -> None:
+    assert set(GRID_METADATA).issubset(set(GridGallery._grids))
+
+
+def test_marketing_candidate_count_pinned() -> None:
+    # SimpleImputer×3 + KNN×2 + Iterative×3 = 8 after constant/"unknown" removal.
+    assert grid_candidate_count("marketing") == 8


### PR DESCRIPTION
## Summary
- Add declarative `GridMetadata` / `GRID_METADATA` as the single source of truth for built-in imputation grids, and enrich `list_grids` with suitability, affinity, complexity, and scale limits.
- Expose `phil://docs/imputation-matrix` (compiled Markdown comparison matrix from metadata **and** live `GridGallery` scalability) and a rule-based `recommend_grid` MCP tool that chooses a grid from dataset scale, categorical cardinality, and missingness.
- Update agent workflow prompt, MCP docs, and README; add unit + MCP coverage for the matrix and recommender.

### Review follow-ups
- **Integer ID heuristic:** only route integer columns to high-cardinality / `marketing` when the name looks ID-like (`zip`, `_id`, `_code`, …) **and** `n_unique >= 50`. Ordinary measurements (`age`, `salary`) stay on `default`.
- **Standalone pipeline (`phil.py`):** gallery methods in `_STANDALONE_IMPUTERS` no longer ignore caller `max_iter` / `random_state` (applied via `get_params`); `MaskedIterativeImputer` still receives `covariate_subsets`. Covered by per-grid smoke + `max_iter` propagation tests.
- **Marketing `SimpleImputer` strategies:** replaced broken `constant`/`fill_value="unknown"` with `most_frequent` / `mean` / `median` (8 candidates total; pinned in tests). Metadata no longer claims TargetEncoder (unwired; needs supervised `y` — follow-up).
- **Warnings / sample budget:** extreme-missingness warnings accumulate independently of grid choice; trigger uses per-column sparsity. Agent-facing sample notes are heuristics (not Rubin's *m*).
- **Parity:** `GRID_METADATA` keys must be a subset of `GridGallery._grids` so stale metadata cannot silently attach the default grid.

Fixes #18

## Test plan
- [x] `uv run --group mcp pytest tests/mcp/test_recommend.py tests/mcp/test_server.py tests/mcp/test_config.py tests/phil/test_grid_pipelines.py -q`
- [x] Integer measurement columns without NAs recommend `default` (not `marketing`)
- [x] High-cardinality + extreme missingness still emits the >50% warning
- [x] `phil://docs/imputation-matrix` complexity section matches live `grid_scalability`
- [x] `recommend_grid` unknown `dataset_id` / bad `data_path` error paths
- [ ] Ingest a small CSV via MCP, call `recommend_grid`, confirm JSON includes `recommended_grid` / `suggested_samples` / `recommendation`
- [ ] `list_grids` still returns healthcare metadata (`time_complexity=High`, `scale_limits`)